### PR TITLE
feat: scale terminal to fit window while preserving aspect ratio

### DIFF
--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
 import { useTerminal } from '../hooks/useTerminal';
 import type { Field } from '../types';
 
@@ -42,6 +42,35 @@ export default function Terminal() {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+  // Responsive scaling: fit terminal to window while preserving aspect ratio
+  const [fontSize, setFontSize] = useState(16);
+  const naturalDimsRef = useRef<{ width: number; height: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const PADDING = 32; // gap kept on each side of the terminal
+    const BASE_FONT_SIZE = 16;
+
+    const computeScale = () => {
+      const el = containerRef.current;
+      if (!el) return;
+
+      // Capture natural (unscaled) dimensions exactly once, at base font-size
+      if (!naturalDimsRef.current) {
+        naturalDimsRef.current = { width: el.offsetWidth, height: el.offsetHeight };
+      }
+
+      const { width: natW, height: natH } = naturalDimsRef.current;
+      const availW = window.innerWidth - PADDING * 2;
+      const availH = window.innerHeight - PADDING * 2;
+      const scale = Math.min(availW / natW, availH / natH);
+      setFontSize(Math.max(8, BASE_FONT_SIZE * scale));
+    };
+
+    computeScale();
+    window.addEventListener('resize', computeScale);
+    return () => window.removeEventListener('resize', computeScale);
+  }, []);
 
   // Row focus state for list navigation
   const [focusedDataRowIndex, setFocusedDataRowIndex] = useState<number | null>(null);
@@ -402,6 +431,7 @@ export default function Terminal() {
       ref={containerRef}
       onKeyDown={handleKeyDown}
       tabIndex={0}
+      style={{ fontSize: `${fontSize}px` }}
     >
       {/* Connection status */}
       <div className={`connection-status ${connected ? 'connected' : 'disconnected'}`}>

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -50,15 +50,12 @@ export default function Terminal() {
   useLayoutEffect(() => {
     const PADDING = 32; // gap kept on each side of the terminal
     const BASE_FONT_SIZE = 16;
+    let cancelled = false;
 
     const computeScale = () => {
       const el = containerRef.current;
-      if (!el) return;
-
-      // Capture natural (unscaled) dimensions exactly once, at base font-size
-      if (!naturalDimsRef.current) {
-        naturalDimsRef.current = { width: el.offsetWidth, height: el.offsetHeight };
-      }
+      // Don't measure until natural dims are known (i.e. after fonts load)
+      if (!el || !naturalDimsRef.current) return;
 
       const { width: natW, height: natH } = naturalDimsRef.current;
       const availW = window.innerWidth - PADDING * 2;
@@ -67,9 +64,22 @@ export default function Terminal() {
       setFontSize(Math.max(8, BASE_FONT_SIZE * scale));
     };
 
-    computeScale();
+    // Wait for the webfont (IBM Plex Mono) to finish loading before capturing
+    // natural dimensions, so measurements are based on actual glyph metrics
+    // rather than fallback font metrics.
+    document.fonts.ready.then(() => {
+      if (cancelled) return;
+      const el = containerRef.current;
+      if (!el) return;
+      naturalDimsRef.current = { width: el.offsetWidth, height: el.offsetHeight };
+      computeScale();
+    });
+
     window.addEventListener('resize', computeScale);
-    return () => window.removeEventListener('resize', computeScale);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('resize', computeScale);
+    };
   }, []);
 
   // Row focus state for list navigation

--- a/client/src/components/Terminal.tsx
+++ b/client/src/components/Terminal.tsx
@@ -45,40 +45,56 @@ export default function Terminal() {
 
   // Responsive scaling: fit terminal to window while preserving aspect ratio
   const [fontSize, setFontSize] = useState(16);
-  const naturalDimsRef = useRef<{ width: number; height: number } | null>(null);
+  const naturalDimsRef = useRef<{ width: number; height: number; baseFontSize: number } | null>(null);
 
   useLayoutEffect(() => {
     const PADDING = 32; // gap kept on each side of the terminal
-    const BASE_FONT_SIZE = 16;
     let cancelled = false;
+    let rafId: number | null = null;
 
     const computeScale = () => {
       const el = containerRef.current;
       // Don't measure until natural dims are known (i.e. after fonts load)
       if (!el || !naturalDimsRef.current) return;
 
-      const { width: natW, height: natH } = naturalDimsRef.current;
+      const { width: natW, height: natH, baseFontSize } = naturalDimsRef.current;
       const availW = window.innerWidth - PADDING * 2;
       const availH = window.innerHeight - PADDING * 2;
       const scale = Math.min(availW / natW, availH / natH);
-      setFontSize(Math.max(8, BASE_FONT_SIZE * scale));
+      setFontSize(Math.max(8, baseFontSize * scale));
+    };
+
+    // Throttle resize via requestAnimationFrame to avoid excessive layout reads
+    // during interactive window resizing.
+    const handleResize = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        computeScale();
+      });
     };
 
     // Wait for the webfont (IBM Plex Mono) to finish loading before capturing
     // natural dimensions, so measurements are based on actual glyph metrics
-    // rather than fallback font metrics.
+    // rather than fallback font metrics. Base font-size is also read from
+    // getComputedStyle so it stays in sync with the CSS definition.
     document.fonts.ready.then(() => {
       if (cancelled) return;
       const el = containerRef.current;
       if (!el) return;
-      naturalDimsRef.current = { width: el.offsetWidth, height: el.offsetHeight };
+      const baseFontSize = parseFloat(getComputedStyle(el).fontSize);
+      naturalDimsRef.current = { width: el.offsetWidth, height: el.offsetHeight, baseFontSize };
       computeScale();
     });
 
-    window.addEventListener('resize', computeScale);
+    window.addEventListener('resize', handleResize);
     return () => {
       cancelled = true;
-      window.removeEventListener('resize', computeScale);
+      window.removeEventListener('resize', handleResize);
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
     };
   }, []);
 

--- a/client/src/styles/terminal.css
+++ b/client/src/styles/terminal.css
@@ -42,7 +42,7 @@ body {
 /* Terminal Container */
 .terminal-container {
   background-color: var(--bg-color);
-  border: 3px solid #1a3a1a;
+  border: 0.1875em solid #1a3a1a;
   border-radius: 12px;
   padding: 1.25em;
   box-shadow:

--- a/client/src/styles/terminal.css
+++ b/client/src/styles/terminal.css
@@ -44,12 +44,13 @@ body {
   background-color: var(--bg-color);
   border: 3px solid #1a3a1a;
   border-radius: 12px;
-  padding: 20px;
-  box-shadow: 
+  padding: 1.25em;
+  box-shadow:
     0 0 20px rgba(51, 255, 51, 0.1),
     inset 0 0 60px rgba(0, 0, 0, 0.5);
   position: relative;
   overflow: hidden;
+  font-size: 16px;
 }
 
 /* CRT screen effect */
@@ -128,7 +129,7 @@ body {
   width: 80ch;
   min-height: calc(22 * 1.4em);
   color: var(--text-color);
-  font-size: 16px;
+  font-size: inherit;
   line-height: 1.4;
   white-space: pre;
   text-shadow: 0 0 5px rgba(51, 255, 51, 0.5);
@@ -187,11 +188,11 @@ body {
   width: 80ch;
   height: 1.4em;
   color: var(--text-dim);
-  font-size: 16px;
+  font-size: inherit;
   line-height: 1.4;
   white-space: pre;
-  margin-top: 4px;
-  padding-top: 4px;
+  margin-top: 0.25em;
+  padding-top: 0.25em;
   border-top: 1px solid #1a3a1a;
 }
 
@@ -199,7 +200,7 @@ body {
 .terminal-message {
   width: 80ch;
   height: 1.4em;
-  font-size: 16px;
+  font-size: inherit;
   line-height: 1.4;
   white-space: pre;
   color: var(--text-color);


### PR DESCRIPTION
Measures natural dimensions at base 16px font-size on mount, then
computes a scale factor from the available viewport (minus 32px
padding on each side) and applies it as a dynamic font-size. All
sizing (80ch widths, 1.4em row heights, input field widths in ch)
inherits from the container font-size so everything scales uniformly.
Padding and status-line margins converted to em units so they scale
proportionally too. Resize listener keeps the terminal fitted when
the browser window changes size.

https://claude.ai/code/session_01U4Nxec54tKj4RuirBsTmkS