### PR TITLE
Add REST API support for CRUDTable configurations

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(docker compose *)",
       "Bash(curl -s http://localhost:3002/mcp/health)",
       "mcp__as500__timereg_v2_list",
-      "mcp__as500__timereg_v2_delete"
+      "mcp__as500__timereg_v2_delete",
+      "Bash(npm run *)"
     ]
   }
 }

--- a/.claude/skills/crudtable/SKILL.md
+++ b/.claude/skills/crudtable/SKILL.md
@@ -245,6 +245,91 @@ npx tsc && node scripts/smoke-mcp.mjs   # walks DCR → consent → token → to
 
 Reference: `server/src/configs/timeRegV2.ts` has a working `mcp` block with scope params. The `MCPConfig` and `MCPOperationOverride` types in `server/src/crudtable/types.ts` are the authoritative shape; `server/src/mcp/schemaBuilder.ts` shows how each field is translated into zod.
 
+## Step 6 (optional) — Expose the config over the REST API
+
+Every CRUDTable config can also be served as a conventional HTTP REST API with **no extra handler code**. Add an `api` block to the config; the runtime at `server/src/api/` mounts routes on `GET/POST/PUT/DELETE /api/<id>[/<id>]` (port 3002) and enforces the same AS500 RBAC that gates the terminal UI and the MCP surface.
+
+```ts
+// Inside your CRUDTableConfig
+api: {
+  name: 'things',          // display name shown by GET /api discovery endpoint
+  description: 'Things managed by the AS500 Thing registry.',
+  operations: {
+    list:   true,          // enable individually; omit/false to disable
+    read:   true,          // requires services.read
+    create: true,
+    update: true,
+    delete: { requirePermission: PERMISSIONS.THINGS_DELETE },
+  },
+  // Scope params: injected into ctx.input before services run.
+  // SECURITY — use injectFromAuth: 'userId' for user-scoped configs; the
+  // runtime injects the token's userId and strips it from the URL so callers
+  // can never pass a different id.
+  scope: [
+    {
+      name: 'userId',
+      type: 'number',
+      required: true,
+      description: 'Injected from the Bearer token.',
+      injectFromAuth: 'userId',   // ← never accepted from the caller
+    },
+    {
+      name: 'date',
+      type: 'string',
+      required: true,
+      description: 'Workday in YYYY-MM-DD format — pass as ?date=…',
+    },
+  ],
+}
+```
+
+HTTP shape for a config with `id = 'things'`:
+
+| Method | URL | Purpose |
+|---|---|---|
+| `GET`    | `/api/things`    | List (paginated: `?offset=&limit=`, max 100) |
+| `GET`    | `/api/things/:id` | Read one record |
+| `POST`   | `/api/things`    | Create (body = writable fields only) |
+| `PUT`    | `/api/things/:id` | Update (body = writable fields only) |
+| `DELETE` | `/api/things/:id` | Delete (returns 204) |
+
+Non-`injectFromAuth` scope params go in the **query string** for all methods. The body contains only the resource's own writable fields.
+
+**Getting a Bearer token for the REST API:**
+
+Option A — First-party app (you own the client):
+```bash
+# Login once
+curl -X POST http://localhost:3002/api/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{ "username": "FREDRIC", "password": "fredric" }'
+# → { "access_token": "...", "refresh_token": "...", "expires_in": 3600 }
+
+# Use on every REST call
+curl http://localhost:3002/api/things?date=2026-04-23 \
+  -H "Authorization: Bearer <access_token>"
+
+# Refresh after 1 hour (old pair revoked, new pair returned)
+curl -X POST http://localhost:3002/api/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{ "refresh_token": "<token>" }'
+```
+
+Option B — Third-party / AI agent: use the full OAuth 2.1 + DCR flow (same as MCP). See `CLAUDE.md § REST API` and `server/scripts/smoke-mcp.mjs`.
+
+**What you get for free:**
+- RBAC enforcement: `config.requirePermission`, `ServiceCall.requirePermission`, per-op `api.operations[op].requirePermission` — admins bypass all three
+- Rate limiting: 300 req/min per client in production (600 in dev)
+- Audit row in `mcp_audit_log` with `source='api'` for every call
+- `services.read` required for `read`, `update`, and `delete` operations (same as MCP)
+
+**Things you still own:**
+- `services.read` must be implemented if any of `read/update/delete` are enabled
+- Scope param names must match the keys your service functions read from `ctx.input`
+- Error format is `{ "error": { "code": "…", "message": "…", "fields": […] } }` — HTTP 400/401/403/404/405/429/500
+
+Reference: `server/src/configs/timeRegV2.ts` has a working `api` block. The `APIConfig` and `APIOperationConfig` types in `server/src/crudtable/types.ts` are the authoritative shape. Full reference in `CLAUDE.md § REST API`.
+
 ## Patterns to reach for
 
 | Need | Use |
@@ -334,7 +419,7 @@ Canonical example: `server/src/configs/motorcyclesConfig.ts` (parent with two re
 
 | File | What it demonstrates |
 |---|---|
-| `server/src/configs/timeRegV2.ts` | `listHeader` + `listKeys` (F7/F8 day nav) + `input`-driven filtering + init helper |
+| `server/src/configs/timeRegV2.ts` | `listHeader` + `listKeys` (F7/F8 day nav) + `input`-driven filtering + init helper + **`mcp` block** + **`api` block** (canonical reference for both remote surfaces) |
 | `server/src/configs/userMgmtConfig.ts` | `staticOptions` select, context-sensitive `required`/`disabled`, password+confirm with validator, `formValue` for booleans |
 | `server/src/configs/roleDefaultsConfig.ts` | Composite primary key, `SYS_ADMIN` gate, validators using a seeded registry |
 | `server/src/configs/motorcyclesConfig.ts` | **`relations`** — two edit-form hotkeys (`M=Mods`, `S=Services`) jumping to scoped child lists via `mapInput` |
@@ -356,6 +441,18 @@ After implementing a new CRUD screen:
 - [ ] Permissions exist in `server/src/services/access.ts` (add them if new) and are seeded for the relevant roles
 - [ ] A `CrudNode` for the config is added to `server/src/menus/menuTree.ts` with the right parent menu, `requirePermission`, and `configId` matching the config's `id`
 - [ ] If the list needs caller context, it is seeded inside `initContext(session)` on the menu node — not from a screen handler and not in the config body
+
+**If adding an `api` block (Step 6):**
+- [ ] `services.read` is implemented (required by `read`, `update`, and `delete`)
+- [ ] `injectFromAuth: 'userId'` is used on any scope param that comes from the logged-in user — never accept userId from the caller
+- [ ] Each non-injected scope param is documented with a `description` (shown in `GET /api` discovery)
+- [ ] Only operations that should be public-facing are enabled in `api.operations`
+- [ ] Smoke-tested with `curl -X POST http://localhost:3002/api/auth/token` + a call to `GET /api/<configId>`
+
+**If adding an `mcp` block (Step 5):**
+- [ ] `services.read` is implemented (required by `update` and `delete`)
+- [ ] `mcp.description` is set (required)
+- [ ] `injectFromAuth: 'userId'` is used for user-scoped scope params
 
 ## When to go beyond the fast path
 

--- a/.cursor/skills/crudtable/SKILL.md
+++ b/.cursor/skills/crudtable/SKILL.md
@@ -245,6 +245,91 @@ npx tsc && node scripts/smoke-mcp.mjs   # walks DCR → consent → token → to
 
 Reference: `server/src/configs/timeRegV2.ts` has a working `mcp` block with scope params. The `MCPConfig` and `MCPOperationOverride` types in `server/src/crudtable/types.ts` are the authoritative shape; `server/src/mcp/schemaBuilder.ts` shows how each field is translated into zod.
 
+## Step 6 (optional) — Expose the config over the REST API
+
+Every CRUDTable config can also be served as a conventional HTTP REST API with **no extra handler code**. Add an `api` block to the config; the runtime at `server/src/api/` mounts routes on `GET/POST/PUT/DELETE /api/<id>[/<id>]` (port 3002) and enforces the same AS500 RBAC that gates the terminal UI and the MCP surface.
+
+```ts
+// Inside your CRUDTableConfig
+api: {
+  name: 'things',          // display name shown by GET /api discovery endpoint
+  description: 'Things managed by the AS500 Thing registry.',
+  operations: {
+    list:   true,          // enable individually; omit/false to disable
+    read:   true,          // requires services.read
+    create: true,
+    update: true,
+    delete: { requirePermission: PERMISSIONS.THINGS_DELETE },
+  },
+  // Scope params: injected into ctx.input before services run.
+  // SECURITY — use injectFromAuth: 'userId' for user-scoped configs; the
+  // runtime injects the token's userId and strips it from the URL so callers
+  // can never pass a different id.
+  scope: [
+    {
+      name: 'userId',
+      type: 'number',
+      required: true,
+      description: 'Injected from the Bearer token.',
+      injectFromAuth: 'userId',   // ← never accepted from the caller
+    },
+    {
+      name: 'date',
+      type: 'string',
+      required: true,
+      description: 'Workday in YYYY-MM-DD format — pass as ?date=…',
+    },
+  ],
+}
+```
+
+HTTP shape for a config with `id = 'things'`:
+
+| Method | URL | Purpose |
+|---|---|---|
+| `GET`    | `/api/things`    | List (paginated: `?offset=&limit=`, max 100) |
+| `GET`    | `/api/things/:id` | Read one record |
+| `POST`   | `/api/things`    | Create (body = writable fields only) |
+| `PUT`    | `/api/things/:id` | Update (body = writable fields only) |
+| `DELETE` | `/api/things/:id` | Delete (returns 204) |
+
+Non-`injectFromAuth` scope params go in the **query string** for all methods. The body contains only the resource's own writable fields.
+
+**Getting a Bearer token for the REST API:**
+
+Option A — First-party app (you own the client):
+```bash
+# Login once
+curl -X POST http://localhost:3002/api/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{ "username": "FREDRIC", "password": "fredric" }'
+# → { "access_token": "...", "refresh_token": "...", "expires_in": 3600 }
+
+# Use on every REST call
+curl http://localhost:3002/api/things?date=2026-04-23 \
+  -H "Authorization: Bearer <access_token>"
+
+# Refresh after 1 hour (old pair revoked, new pair returned)
+curl -X POST http://localhost:3002/api/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{ "refresh_token": "<token>" }'
+```
+
+Option B — Third-party / AI agent: use the full OAuth 2.1 + DCR flow (same as MCP). See `CLAUDE.md § REST API` and `server/scripts/smoke-mcp.mjs`.
+
+**What you get for free:**
+- RBAC enforcement: `config.requirePermission`, `ServiceCall.requirePermission`, per-op `api.operations[op].requirePermission` — admins bypass all three
+- Rate limiting: 300 req/min per client in production (600 in dev)
+- Audit row in `mcp_audit_log` with `source='api'` for every call
+- `services.read` required for `read`, `update`, and `delete` operations (same as MCP)
+
+**Things you still own:**
+- `services.read` must be implemented if any of `read/update/delete` are enabled
+- Scope param names must match the keys your service functions read from `ctx.input`
+- Error format is `{ "error": { "code": "…", "message": "…", "fields": […] } }` — HTTP 400/401/403/404/405/429/500
+
+Reference: `server/src/configs/timeRegV2.ts` has a working `api` block. The `APIConfig` and `APIOperationConfig` types in `server/src/crudtable/types.ts` are the authoritative shape. Full reference in `CLAUDE.md § REST API`.
+
 ## Patterns to reach for
 
 | Need | Use |
@@ -334,7 +419,7 @@ Canonical example: `server/src/configs/motorcyclesConfig.ts` (parent with two re
 
 | File | What it demonstrates |
 |---|---|
-| `server/src/configs/timeRegV2.ts` | `listHeader` + `listKeys` (F7/F8 day nav) + `input`-driven filtering + init helper |
+| `server/src/configs/timeRegV2.ts` | `listHeader` + `listKeys` (F7/F8 day nav) + `input`-driven filtering + init helper + **`mcp` block** + **`api` block** (canonical reference for both remote surfaces) |
 | `server/src/configs/userMgmtConfig.ts` | `staticOptions` select, context-sensitive `required`/`disabled`, password+confirm with validator, `formValue` for booleans |
 | `server/src/configs/roleDefaultsConfig.ts` | Composite primary key, `SYS_ADMIN` gate, validators using a seeded registry |
 | `server/src/configs/motorcyclesConfig.ts` | **`relations`** — two edit-form hotkeys (`M=Mods`, `S=Services`) jumping to scoped child lists via `mapInput` |
@@ -356,6 +441,18 @@ After implementing a new CRUD screen:
 - [ ] Permissions exist in `server/src/services/access.ts` (add them if new) and are seeded for the relevant roles
 - [ ] A `CrudNode` for the config is added to `server/src/menus/menuTree.ts` with the right parent menu, `requirePermission`, and `configId` matching the config's `id`
 - [ ] If the list needs caller context, it is seeded inside `initContext(session)` on the menu node — not from a screen handler and not in the config body
+
+**If adding an `api` block (Step 6):**
+- [ ] `services.read` is implemented (required by `read`, `update`, and `delete`)
+- [ ] `injectFromAuth: 'userId'` is used on any scope param that comes from the logged-in user — never accept userId from the caller
+- [ ] Each non-injected scope param is documented with a `description` (shown in `GET /api` discovery)
+- [ ] Only operations that should be public-facing are enabled in `api.operations`
+- [ ] Smoke-tested with `curl -X POST http://localhost:3002/api/auth/token` + a call to `GET /api/<configId>`
+
+**If adding an `mcp` block (Step 5):**
+- [ ] `services.read` is implemented (required by `update` and `delete`)
+- [ ] `mcp.description` is set (required)
+- [ ] `injectFromAuth: 'userId'` is used for user-scoped scope params
 
 ## When to go beyond the fast path
 

--- a/.github/instructions/crudtable.instructions.md
+++ b/.github/instructions/crudtable.instructions.md
@@ -24,6 +24,8 @@ For deep reference, read:
 - **List + create/edit/delete on some entity?** → CRUDTable config in `server/src/configs/`, then expose it via a node in `server/src/menus/menuTree.ts`.
 - **Main menu, submenu, any grouped navigation?** → Add a `MenuNode` to `server/src/menus/menuTree.ts`. Never hand-roll a menu screen; `server/src/menus/menuRuntime.ts` renders every menu generically.
 - **Login, help, dashboard, wizard?** → Manual DSL screen in `server/src/screens/`.
+- **Expose data to a remote app via REST?** → Add an `api` block to the `CRUDTableConfig` (Step 6 in the SKILL). The runtime mounts `/api/<configId>` on port 3002 automatically. Use `POST /api/auth/token` for first-party Bearer token login.
+- **Expose data to an AI agent via MCP?** → Add an `mcp` block to the `CRUDTableConfig` (Step 5 in the SKILL).
 
 ## Authoring shape (must follow)
 
@@ -44,7 +46,7 @@ Screen IDs are always `CRUD_{config.id.toUpperCase()}` (CRUD screens) or `MENU_{
 
 ## Working examples to pattern-match against
 
-- `server/src/configs/timeRegV2.ts` — dynamic `listHeader`, F7/F8 `listKeys`, `input`-driven list params
+- `server/src/configs/timeRegV2.ts` — dynamic `listHeader`, F7/F8 `listKeys`, `input`-driven list params, **`mcp` block**, **`api` block** (canonical reference for both remote surfaces)
 - `server/src/configs/userMgmtConfig.ts` — `staticOptions` select, context-sensitive `required`/`disabled`, password + confirm validator, `formValue` mapping
 - `server/src/configs/roleDefaultsConfig.ts` — composite primary key, `SYS_ADMIN` gate
 
@@ -59,3 +61,12 @@ Open one of these before writing a config from scratch.
 - [ ] Permissions used are declared in `access.ts` and seeded for the roles that need them
 - [ ] A `CrudNode` is added to `server/src/menus/menuTree.ts` under the correct parent, with matching `configId` and the correct `requirePermission` guard
 - [ ] Per-user list filtering, if any, lives in `initContext` on the menu node — not in a screen handler
+
+**If adding an `api` block:**
+- [ ] `services.read` is implemented
+- [ ] User-scoped params use `injectFromAuth: 'userId'` — never accept `userId` from callers
+- [ ] Smoke-tested: `POST /api/auth/token` → `GET /api/<configId>`
+
+**If adding an `mcp` block:**
+- [ ] `services.read` is implemented; `mcp.description` is set
+- [ ] User-scoped params use `injectFromAuth: 'userId'`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,114 @@ Any CRUDTable config can be exposed to remote AI agents as a set of MCP tools by
 
 ---
 
+## REST API
+
+Any CRUDTable config can be exposed as standard REST endpoints by adding an `api` block alongside (or instead of) the `mcp` block. The runtime at `server/src/api/` mounts routes on the MCP Express app at `/api/{config.id}[/{id}]` (port 3002).
+
+**Two ways to get a Bearer token:**
+
+| Scenario | Endpoint | Notes |
+|---|---|---|
+| **First-party app** (you own the client) | `POST /api/auth/token` | Submit username + password directly — no browser redirect needed |
+| **Third-party / AI agent** (OAuth 2.1 flow) | `POST /register` → `GET /authorize` → `POST /token` | Full DCR + PKCE consent flow — user approves in the browser |
+
+Both paths produce identical HS256 JWTs accepted by `Authorization: Bearer` on every `/api/*` call.
+
+**Transport**: Routes mounted at `/api/…` on the MCP Express app (port 3002).
+
+| Method | URL | Operation |
+|--------|-----|-----------|
+| `GET`  | `/api` | Discovery — list all exposed configs + enabled ops |
+| `GET`  | `/api/:configId` | List (paginated via `?offset=&limit=`, max 100) |
+| `GET`  | `/api/:configId/:id` | Read single record |
+| `POST` | `/api/:configId` | Create |
+| `PUT`  | `/api/:configId/:id` | Update |
+| `DELETE` | `/api/:configId/:id` | Delete (204 no body) |
+
+**Auth**: Same OAuth 2.1 Bearer token flow as MCP. Pass `Authorization: Bearer <token>` on every request.
+
+**Scope params**: Configured on `api.scope`. Params with `injectFromAuth: 'userId'` are NEVER accepted from callers — injected server-side from the token. Other scope params are resolved from the **query string** for all HTTP methods (not the body). The body contains only the resource's own writable fields.
+
+**Error response format**:
+```json
+{ "error": { "code": "validation_failed", "message": "…", "fields": [{ "name": "f", "message": "…" }] } }
+```
+HTTP status codes: 400 validation, 401 unauthenticated, 403 permission denied, 404 not found, 405 op not enabled, 429 rate limited, 500 internal.
+
+**Adding a CRUDTable config to the REST API surface**: add an `api` block on the `CRUDTableConfig`:
+
+```typescript
+api: {
+  name: 'timereg',         // display name (discovery only); URL path is always config.id
+  description: '...',
+  operations: { list: true, read: true, create: true, update: true, delete: true },
+  scope: [
+    {
+      name: 'userId', type: 'number', required: true,
+      description: 'Injected from token.', injectFromAuth: 'userId',
+    },
+    {
+      name: 'date', type: 'string', required: true,
+      description: 'Workday YYYY-MM-DD — pass as ?date=…',
+    },
+  ],
+}
+```
+
+No code changes anywhere else. The registry validates the block at startup. See `server/src/configs/timeRegV2.ts` for the canonical example.
+
+**Audit**: every API call writes a row to `mcp_audit_log` with `source='api'` (same table as MCP, distinguishable by the `source` column). The audit admin screen shows both MCP and REST calls.
+
+**Key files**:
+| Purpose | Path |
+|---------|------|
+| REST router (Express, mounted at `/api`) | `server/src/api/index.ts` |
+| Per-op REST handlers | `server/src/api/handlers.ts` |
+| First-party auth router | `server/src/api/auth.ts` |
+
+### First-party login (for apps you own and control)
+
+If you own both the client app and the AS500 backend, skip the OAuth redirect dance entirely. Use the credential-exchange endpoints at `/api/auth` to get Bearer tokens directly.
+
+**Login:**
+```http
+POST http://localhost:3002/api/auth/token
+Content-Type: application/json
+
+{ "username": "FREDRIC", "password": "fredric" }
+```
+```json
+{ "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "<opaque>" }
+```
+
+**Use the token on every REST call:**
+```http
+GET http://localhost:3002/api/timereg_v2?date=2026-04-23
+Authorization: Bearer <access_token>
+```
+
+**Refresh before/after the 1-hour expiry:**
+```http
+POST http://localhost:3002/api/auth/refresh
+Content-Type: application/json
+
+{ "refresh_token": "<opaque>" }
+```
+Returns a new `access_token` + new `refresh_token`. The old pair is immediately revoked (rotation).
+
+**Logout:**
+```http
+POST http://localhost:3002/api/auth/revoke
+Content-Type: application/json
+
+{ "token": "<refresh_token_or_access_token>", "token_type_hint": "refresh_token" }
+```
+Always returns `{ "ok": true }`. Omit `token_type_hint` to try both types. Pass `"access_token"` or `"refresh_token"` as a hint.
+
+Tokens issued this way carry sentinel `client_id = 'as500-direct'` and are otherwise identical to OAuth-issued tokens — same JWT format, same RBAC enforcement on every REST call, same audit logging.
+
+---
+
 ## Key Files
 
 | Purpose | Path |
@@ -324,6 +432,9 @@ Any CRUDTable config can be exposed to remote AI agents as a set of MCP tools by
 | **MCP tool handlers (per-op)** | `server/src/mcp/toolHandlers.ts` |
 | **MCP OAuth provider** | `server/src/mcp/oauth/provider.ts` |
 | **MCP audit log writer** | `server/src/mcp/audit.ts` |
+| **REST API router** | `server/src/api/index.ts` |
+| **REST API handlers** | `server/src/api/handlers.ts` |
+| **First-party auth router** | `server/src/api/auth.ts` |
 | Terminal hook (WebSocket) | `client/src/hooks/useTerminal.ts` |
 | Terminal renderer | `client/src/components/Terminal.tsx` |
 | Terminal styles | `client/src/styles/terminal.css` |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A modern client-server solution that emulates an AS400 mainframe terminal. The b
 - **Mouse row selection** — Click to select a row, double-click to open
 - **Modern token-based authentication** — OAuth 2.0-inspired access/refresh token pattern
 - **Remote MCP server** — every CRUDTable config can be opened up to AI agents as [Model Context Protocol](https://modelcontextprotocol.io) tools, gated by OAuth 2.1 + DCR and the same RBAC as the UI
+- **REST API** — same CRUDTable configs also served as a conventional REST API (`GET/POST/PUT/DELETE /api/:configId`) with first-party Bearer token login (`POST /api/auth/token`) and token rotation
 - **Secure session management** — 30-day auto-login with 1-hour token rotation
 - **Role-based access control** — Roles (`user`, `superuser`, `aiagent`, `admin`), user groups, and named permission keys with per-operation CRUDTable enforcement
 - **Device tracking** — Multi-device session management with device fingerprinting
@@ -102,6 +103,12 @@ Open http://localhost:5173 and login with:
 ┌─────────────┐     Streamable HTTP       │
 │  AI agent   │◄──────────────────────────┤  :3002 /mcp
 │ (MCP client)│   OAuth 2.1 + DCR         │  (tools = CRUDTable ops)
+└─────────────┘                           │
+                                          │
+┌─────────────┐     REST HTTP             │
+│  Remote app │◄──────────────────────────┤  :3002 /api
+│  (1st party)│   Bearer token            │  (CRUD resources)
+│             │   POST /api/auth/token    │
 └─────────────┘                           │
                                    ┌──────▼──────┐
                                    │ PostgreSQL  │
@@ -217,6 +224,10 @@ Runs on its own port (default `3002`) with the MCP **Streamable HTTP** transport
 | `GET  /authorize` → `POST /authorize/consent`              | Green-on-black consent page, dedicated `mcpLogin` (separate from AS500 session auth) |
 | `POST /token`                                              | Authorization-code and refresh-token grants, PKCE-enforced |
 | `POST /revoke`                                             | RFC 7009 token revocation |
+| `GET/POST/PUT/DELETE /api/:configId[/:id]`                 | REST API — Bearer-authed, same RBAC + audit as MCP (see [REST API](#rest-api)) |
+| `POST /api/auth/token`                                     | First-party login: username + password → Bearer tokens |
+| `POST /api/auth/refresh`                                   | Rotate refresh token → new access + refresh pair |
+| `POST /api/auth/revoke`                                    | Revoke a token (logout) |
 
 ### Auth posture
 
@@ -354,6 +365,90 @@ DELETE FROM oauth_clients WHERE id = 'CLIENT_ID';
 **What the agent can do** is governed entirely by your existing RBAC. The agent inherits the AS500 user's permissions at consent time — no extra grant dialog per tool, no privilege widening. Every call it makes lands in `mcp_audit_log` with the client id + user id + tool + outcome.
 
 > **Security note:** in production, set `AS500_MCP_JWT_SECRET` to a fixed ≥32-char value and put `/mcp` behind your TLS termination. The dev default regenerates the JWT secret on each server restart, which would invalidate every agent's access token.
+
+## REST API
+
+Any CRUDTable config with an `api` block is also available as a conventional REST API on port 3002. Same Bearer tokens, same RBAC, same audit log as MCP — just plain HTTP instead of JSON-RPC.
+
+### Endpoints
+
+| Method | URL | Purpose |
+|--------|-----|---------|
+| `GET`    | `/api`                    | Discovery — list all exposed resources |
+| `GET`    | `/api/:configId`          | List records (`?offset=&limit=`, max 100) |
+| `GET`    | `/api/:configId/:id`      | Read one record |
+| `POST`   | `/api/:configId`          | Create |
+| `PUT`    | `/api/:configId/:id`      | Update |
+| `DELETE` | `/api/:configId/:id`      | Delete (204, no body) |
+
+Scope params with `injectFromAuth: 'userId'` are injected server-side from the token — callers never send them. All other scope params go in the **query string**; the body contains only the resource's own fields.
+
+### Getting a Bearer token — first-party login
+
+If you own both the client app and the AS500 backend, skip the OAuth redirect dance. Use the credential-exchange endpoints:
+
+**1. Login — exchange credentials for tokens**
+```bash
+curl -X POST http://localhost:3002/api/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{ "username": "FREDRIC", "password": "fredric" }'
+```
+```json
+{
+  "access_token": "<JWT>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "<opaque-30d>"
+}
+```
+
+**2. Call the API**
+```bash
+curl http://localhost:3002/api/timereg_v2?date=2026-04-23 \
+  -H "Authorization: Bearer <access_token>"
+```
+
+**3. Refresh after 1 hour (tokens rotate — old pair is revoked)**
+```bash
+curl -X POST http://localhost:3002/api/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{ "refresh_token": "<opaque>" }'
+```
+
+**4. Logout**
+```bash
+curl -X POST http://localhost:3002/api/auth/revoke \
+  -H "Content-Type: application/json" \
+  -d '{ "token": "<refresh_token>", "token_type_hint": "refresh_token" }'
+```
+
+> **Third-party / AI agent?** Use the full OAuth 2.1 + DCR flow described in the Remote MCP Server section above. Both flows produce identical JWTs accepted on every `/api/*` call.
+
+### Error format
+
+```json
+{ "error": { "code": "validation_failed", "message": "…", "fields": [{ "name": "f", "message": "…" }] } }
+```
+
+HTTP status codes: 400 validation, 401 unauthenticated, 403 permission denied, 404 not found, 405 operation not enabled, 429 rate limited, 500 internal.
+
+### Exposing a CRUDTable config on the REST API
+
+Add an `api` block to the `CRUDTableConfig` — no other changes needed:
+
+```typescript
+api: {
+  name: 'timereg',
+  description: 'Time registration entries.',
+  operations: { list: true, read: true, create: true, update: true, delete: true },
+  scope: [
+    { name: 'userId', type: 'number', required: true, injectFromAuth: 'userId' },
+    { name: 'date',   type: 'string', required: true, description: 'YYYY-MM-DD' },
+  ],
+}
+```
+
+See `server/src/configs/timeRegV2.ts` for a working example.
 
 ## Authentication & Security
 
@@ -521,5 +616,11 @@ See [CLAUDE.md § Remote MCP Server](CLAUDE.md#remote-mcp-server) for MCP server
 - `auth_tokens` column reuse for MCP-kind tokens
 - `mcp_audit_log` schema and retention considerations
 - How to expose a new CRUDTable config as MCP tools
+
+See [CLAUDE.md § REST API](CLAUDE.md#rest-api) for the REST API reference:
+- Endpoint table and error format
+- First-party login flow (`POST /api/auth/token`)
+- How to expose a CRUDTable config on the REST surface (`api` block)
+- Scope params and `injectFromAuth`
 
 

--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -1,0 +1,219 @@
+// First-party login endpoints for direct REST API access.
+//
+// This is NOT OAuth — it's a simple credential exchange designed for
+// first-party applications where the developer owns both the client app
+// and the AS500 backend. The caller supplies username + password; the
+// server returns the same access + refresh token pair the OAuth flow
+// would produce. Those tokens are then passed as `Authorization: Bearer`
+// on every REST API call, exactly as MCP clients do.
+//
+// Endpoints mounted at /api/auth (by mcp/index.ts, BEFORE /api so this
+// prefix wins):
+//
+//   POST /api/auth/token   — exchange credentials → access + refresh token
+//   POST /api/auth/refresh — rotate an expired access token via refresh token
+//   POST /api/auth/revoke  — logout: revoke one or both tokens
+//
+// Auth posture:
+//   - Tokens are the same HS256 JWTs the MCP OAuth flow mints; the same
+//     `bearerAuth` middleware validates them on every /api/* call.
+//   - client_id is the sentinel 'as500-direct' (no row in oauth_clients).
+//   - Rate limited: 10 attempts/min per IP for /token.
+//   - Audit: login and revoke are NOT written to mcp_audit_log (no tool
+//     context). REST API calls made with the issued tokens ARE audited normally.
+
+import { Router, type Request, type Response } from 'express';
+import { eq } from 'drizzle-orm';
+import { db } from '../db/index.js';
+import { users } from '../db/schema.js';
+import { mcpLogin } from '../mcp/oauth/login.js';
+import {
+  issueAccessToken,
+  ACCESS_TOKEN_EXPIRY_SECONDS,
+  revokeAccessTokenByJti,
+  verifyAccessToken,
+} from '../mcp/oauth/tokens.js';
+import {
+  createRefreshToken,
+  findLiveRefresh,
+  revokeRefreshToken,
+} from '../mcp/oauth/store.js';
+import { directLoginRateLimiter } from '../utils/rateLimiter.js';
+
+// Sentinel client_id for first-party direct-login tokens.
+// Distinguishable from OAuth-issued tokens in the auth_tokens table.
+export const DIRECT_CLIENT_ID = 'as500-direct';
+
+// ============================================
+// Helpers
+// ============================================
+
+function ipKey(req: Request): string {
+  return req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+}
+
+async function usernameForId(userId: number): Promise<string> {
+  const rows = await db
+    .select({ username: users.username })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return rows[0]?.username ?? `user-${userId}`;
+}
+
+// ============================================
+// Router
+// ============================================
+
+export function buildAuthRouter(): Router {
+  const router = Router();
+
+  // -------- POST /api/auth/token --------
+  // Body: { username: string, password: string }
+  // Response: { access_token, token_type, expires_in, refresh_token }
+  router.post('/token', async (req: Request, res: Response) => {
+    if (!directLoginRateLimiter.check(`login:${ipKey(req)}`)) {
+      res.setHeader('Retry-After', '60');
+      res.status(429).json({
+        error: { code: 'rate_limited', message: 'Too many login attempts. Try again in a minute.' },
+      });
+      return;
+    }
+
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const rawUsername = typeof body.username === 'string' ? body.username : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+
+    if (!rawUsername || !password) {
+      res.status(400).json({
+        error: { code: 'invalid_request', message: 'username and password are required.' },
+      });
+      return;
+    }
+
+    const result = await mcpLogin(rawUsername, password);
+    if (!result.ok) {
+      const message =
+        result.reason === 'rate_limited'
+          ? 'Too many login attempts. Try again in a minute.'
+          : result.reason === 'inactive'
+            ? 'Account is inactive.'
+            : 'Invalid username or password.';
+      res.status(401).json({ error: { code: 'invalid_credentials', message } });
+      return;
+    }
+
+    const { user } = result;
+    try {
+      const refreshToken = await createRefreshToken({
+        userId: user.id,
+        clientId: DIRECT_CLIENT_ID,
+        scope: '',
+      });
+
+      const issued = await issueAccessToken({
+        userId: user.id,
+        username: user.username,
+        clientId: DIRECT_CLIENT_ID,
+        scopes: [],
+        parentRefreshToken: refreshToken,
+      });
+
+      res.json({
+        access_token: issued.accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_EXPIRY_SECONDS,
+        refresh_token: refreshToken,
+      });
+    } catch (err) {
+      console.error('[api/auth] token issuance failed:', err);
+      res.status(500).json({ error: { code: 'server_error', message: 'Failed to issue tokens.' } });
+    }
+  });
+
+  // -------- POST /api/auth/refresh --------
+  // Body: { refresh_token: string }
+  // Response: { access_token, token_type, expires_in, refresh_token }
+  router.post('/refresh', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const tokenValue = typeof body.refresh_token === 'string' ? body.refresh_token : '';
+
+    if (!tokenValue) {
+      res.status(400).json({
+        error: { code: 'invalid_request', message: 'refresh_token is required.' },
+      });
+      return;
+    }
+
+    const live = await findLiveRefresh(tokenValue, DIRECT_CLIENT_ID);
+    if (!live) {
+      res.status(401).json({
+        error: { code: 'invalid_token', message: 'Refresh token is invalid, expired, or already used.' },
+      });
+      return;
+    }
+
+    try {
+      // Rotate: revoke old pair, issue new pair.
+      await revokeRefreshToken(tokenValue);
+
+      const newRefresh = await createRefreshToken({
+        userId: live.userId,
+        clientId: DIRECT_CLIENT_ID,
+        scope: live.scope ?? '',
+      });
+
+      const username = await usernameForId(live.userId);
+
+      const issued = await issueAccessToken({
+        userId: live.userId,
+        username,
+        clientId: DIRECT_CLIENT_ID,
+        scopes: live.scope ? live.scope.split(' ').filter(Boolean) : [],
+        parentRefreshToken: newRefresh,
+      });
+
+      res.json({
+        access_token: issued.accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_EXPIRY_SECONDS,
+        refresh_token: newRefresh,
+      });
+    } catch (err) {
+      console.error('[api/auth] refresh failed:', err);
+      res.status(500).json({ error: { code: 'server_error', message: 'Failed to rotate tokens.' } });
+    }
+  });
+
+  // -------- POST /api/auth/revoke --------
+  // Body: { token: string, token_type_hint?: 'access_token' | 'refresh_token' }
+  // Response: { ok: true }  (always 200, per convention — never reveal whether token existed)
+  router.post('/revoke', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const token = typeof body.token === 'string' ? body.token : '';
+    const hint = typeof body.token_type_hint === 'string' ? body.token_type_hint : '';
+
+    if (!token) {
+      res.status(400).json({ error: { code: 'invalid_request', message: 'token is required.' } });
+      return;
+    }
+
+    try {
+      if (hint === 'refresh_token' || !hint) {
+        await revokeRefreshToken(token);
+      }
+      if (hint === 'access_token' || !hint) {
+        const claims = await verifyAccessToken(token);
+        if (claims?.jti) {
+          await revokeAccessTokenByJti(claims.jti);
+        }
+      }
+    } catch {
+      // Silently swallow — revocation always returns 200.
+    }
+
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/server/src/api/handlers.ts
+++ b/server/src/api/handlers.ts
@@ -1,0 +1,302 @@
+// Per-operation REST API handlers for CRUDTable-backed resources.
+//
+// Each exported function handles one HTTP operation end-to-end:
+//   1. Check permissions (config, ServiceCall, per-op api override).
+//   2. Synthesize the CRUDContext using the api scope config.
+//   3. Run field validators (create/update only).
+//   4. Invoke the ServiceCall from `config.services`.
+//   5. Return an ApiResult with HTTP status + JSON body.
+//
+// Permission errors, validation errors, and not-found cases all surface as
+// structured ApiResult bodies rather than thrown exceptions — callers convert
+// them to Express responses. Any unexpected thrown value becomes a 500.
+
+import type { CRUDTableConfig, APIOperationConfig, ServiceCall } from '../crudtable/types.js';
+import { synthesizeContext, type McpCallUser } from '../mcp/contextSynth.js';
+import { invokeServiceCall, runValidators, assertService } from '../mcp/toolHandlers.js';
+import { McpToolError } from '../mcp/errors.js';
+import type { McpOp } from '../mcp/schemaBuilder.js';
+
+export const API_LIST_LIMIT_DEFAULT = 50;
+export const API_LIST_LIMIT_MAX = 100;
+
+// ============================================
+// Result type
+// ============================================
+
+export interface ApiResult {
+  status: number;
+  body: unknown;
+}
+
+// ============================================
+// Permission check
+// ============================================
+
+function requireApiPermissions(
+  config: CRUDTableConfig,
+  op: McpOp,
+  service: ServiceCall | undefined,
+  user: McpCallUser
+): void {
+  if (user.isAdmin) return;
+  if (!service) return; // assertService will have caught this before we reach here
+
+  const missing: string[] = [];
+  const check = (key: string | undefined): void => {
+    if (!key) return;
+    if (!user.permissions.has(key)) missing.push(key);
+  };
+
+  check(config.requirePermission);
+  check(service.requirePermission);
+
+  const opEntry = config.api?.operations?.[op];
+  if (opEntry && typeof opEntry === 'object') {
+    check((opEntry as APIOperationConfig).requirePermission);
+  }
+
+  if (missing.length > 0) {
+    const unique = Array.from(new Set(missing));
+    throw new McpToolError(
+      'permission_denied',
+      `Missing required permission${unique.length > 1 ? 's' : ''}: ${unique.join(', ')}`,
+      unique.map((m) => ({ name: m, message: 'Permission not granted to caller.' }))
+    );
+  }
+}
+
+// ============================================
+// Pre-fetch helper
+// ============================================
+
+async function fetchById(
+  config: CRUDTableConfig,
+  scopeInput: Record<string, unknown>,
+  id: number,
+  user: McpCallUser
+): Promise<Record<string, unknown> | null> {
+  assertService(config.services.read, 'read');
+  const readCtx = synthesizeContext({
+    config,
+    op: 'read',
+    input: { ...scopeInput, id },
+    user,
+    scopeParams: config.api?.scope,
+  });
+  const rec = (await invokeServiceCall(config.services.read, readCtx)) as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  return rec ?? null;
+}
+
+// ============================================
+// Error → ApiResult
+// ============================================
+
+function errorCodeToStatus(code: McpToolError['code']): number {
+  switch (code) {
+    case 'validation_failed': return 400;
+    case 'permission_denied': return 403;
+    case 'not_found':         return 404;
+    case 'unsupported_operation': return 405;
+    case 'rate_limited':      return 429;
+    default:                  return 500;
+  }
+}
+
+export function apiResultFromThrown(err: unknown, debug: boolean): ApiResult {
+  if (err instanceof McpToolError) {
+    return {
+      status: errorCodeToStatus(err.code),
+      body: {
+        error: {
+          code: err.code,
+          message: err.message,
+          ...(err.fields ? { fields: err.fields } : {}),
+        },
+      },
+    };
+  }
+  const raw = err instanceof Error ? err.message : String(err);
+  const message = debug ? raw : 'Internal server error';
+  return {
+    status: 500,
+    body: { error: { code: 'internal_error', message } },
+  };
+}
+
+// ============================================
+// Handler args
+// ============================================
+
+export interface ApiHandlerArgs {
+  config: CRUDTableConfig;
+  /** Scope input pre-built by the router (auth-injected + query-resolved). */
+  scopeInput: Record<string, unknown>;
+  user: McpCallUser;
+}
+
+// ============================================
+// List
+// ============================================
+
+export async function handleApiList(
+  args: ApiHandlerArgs & { query: Record<string, unknown> }
+): Promise<ApiResult> {
+  const { config, scopeInput, user, query } = args;
+  assertService(config.services.list, 'list');
+  requireApiPermissions(config, 'list', config.services.list, user);
+
+  const rawLimit = Number(query.limit ?? API_LIST_LIMIT_DEFAULT);
+  const limit = Math.min(Math.max(1, Math.floor(isNaN(rawLimit) ? API_LIST_LIMIT_DEFAULT : rawLimit)), API_LIST_LIMIT_MAX);
+  const rawOffset = Number(query.offset ?? 0);
+  const offset = Math.max(0, Math.floor(isNaN(rawOffset) ? 0 : rawOffset));
+
+  const input = { ...scopeInput, limit, offset };
+  const ctx = synthesizeContext({ config, op: 'list', input, user, scopeParams: config.api?.scope });
+  const allRaw = (await invokeServiceCall(config.services.list, ctx)) as unknown;
+  const all = Array.isArray(allRaw) ? (allRaw as Record<string, unknown>[]) : [];
+
+  const totalRecords = all.length;
+  const page = all.slice(offset, offset + limit);
+  const hasMore = offset + page.length < totalRecords;
+
+  return {
+    status: 200,
+    body: { records: page, totalRecords, offset, limit, hasMore },
+  };
+}
+
+// ============================================
+// Read
+// ============================================
+
+export async function handleApiRead(
+  args: ApiHandlerArgs & { id: number }
+): Promise<ApiResult> {
+  const { config, scopeInput, user, id } = args;
+  assertService(config.services.read, 'read');
+  requireApiPermissions(config, 'read', config.services.read, user);
+
+  const input = { ...scopeInput, id };
+  const ctx = synthesizeContext({ config, op: 'read', input, user, scopeParams: config.api?.scope });
+  const rec = (await invokeServiceCall(config.services.read, ctx)) as
+    | Record<string, unknown>
+    | null
+    | undefined;
+
+  if (rec === null || rec === undefined) {
+    throw new McpToolError('not_found', `No ${config.title} record found for id=${id}.`);
+  }
+
+  return { status: 200, body: { record: rec } };
+}
+
+// ============================================
+// Create
+// ============================================
+
+export async function handleApiCreate(
+  args: ApiHandlerArgs & { body: Record<string, unknown> }
+): Promise<ApiResult> {
+  const { config, scopeInput, user, body } = args;
+  assertService(config.services.create, 'create');
+  requireApiPermissions(config, 'create', config.services.create, user);
+
+  // Scope keys win over body to prevent callers from overriding injected values.
+  const input = { ...body, ...scopeInput };
+  const ctx = synthesizeContext({ config, op: 'create', input, user, scopeParams: config.api?.scope });
+
+  const validationErrors = runValidators(config, ctx);
+  if (validationErrors.length > 0) {
+    throw new McpToolError(
+      'validation_failed',
+      `Input failed field validation (${validationErrors.length} error(s)).`,
+      validationErrors
+    );
+  }
+
+  const created = (await invokeServiceCall(config.services.create, ctx)) as
+    | Record<string, unknown>
+    | undefined;
+
+  return { status: 201, body: created ? { record: created } : {} };
+}
+
+// ============================================
+// Update
+// ============================================
+
+export async function handleApiUpdate(
+  args: ApiHandlerArgs & { id: number; body: Record<string, unknown> }
+): Promise<ApiResult> {
+  const { config, scopeInput, user, id, body } = args;
+  assertService(config.services.update, 'update');
+  assertService(config.services.read, 'update'); // need read to populate editRecord
+  requireApiPermissions(config, 'update', config.services.update, user);
+
+  const existing = await fetchById(config, scopeInput, id, user);
+  if (!existing) {
+    throw new McpToolError('not_found', `No ${config.title} record found for id=${id}.`);
+  }
+
+  // Scope keys win over body to prevent callers from overriding injected values.
+  const input = { ...body, id, ...scopeInput };
+  const ctx = synthesizeContext({
+    config,
+    op: 'update',
+    input,
+    editRecord: existing,
+    user,
+    scopeParams: config.api?.scope,
+  });
+
+  const validationErrors = runValidators(config, ctx);
+  if (validationErrors.length > 0) {
+    throw new McpToolError(
+      'validation_failed',
+      `Input failed field validation (${validationErrors.length} error(s)).`,
+      validationErrors
+    );
+  }
+
+  const updated = (await invokeServiceCall(config.services.update, ctx)) as
+    | Record<string, unknown>
+    | undefined;
+
+  return { status: 200, body: updated ? { record: updated } : {} };
+}
+
+// ============================================
+// Delete
+// ============================================
+
+export async function handleApiDelete(
+  args: ApiHandlerArgs & { id: number }
+): Promise<ApiResult> {
+  const { config, scopeInput, user, id } = args;
+  assertService(config.services.delete, 'delete');
+  assertService(config.services.read, 'delete'); // need read to populate selection/deleteRecord
+  requireApiPermissions(config, 'delete', config.services.delete, user);
+
+  const existing = await fetchById(config, scopeInput, id, user);
+  if (!existing) {
+    throw new McpToolError('not_found', `No ${config.title} record found for id=${id}.`);
+  }
+
+  const input = { ...scopeInput, id };
+  const ctx = synthesizeContext({
+    config,
+    op: 'delete',
+    input,
+    deleteRecord: existing,
+    user,
+    scopeParams: config.api?.scope,
+  });
+
+  await invokeServiceCall(config.services.delete, ctx);
+
+  return { status: 204, body: null };
+}

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,0 +1,385 @@
+// Express router for the REST API layer.
+//
+// Mounted at `/api` on the MCP Express app (port 3002). Every CRUDTable config
+// with an `api` block gets five routes: list, read, create, update, delete.
+//
+// Auth: same OAuth 2.1 Bearer tokens as MCP — passed in as `bearerAuth`
+// middleware so the same `requireBearerAuth` instance covers both surfaces.
+//
+// Scope params:
+//   - `injectFromAuth` params are resolved from the Bearer token (never from
+//     the request). All other scope params are resolved from the query string.
+//   - The request body (create/update) contains only the resource's own fields.
+//
+// Audit: every request writes a row to `mcp_audit_log` with `source='api'`,
+// fire-and-forget (same as MCP).
+
+import { Router, type Request, type Response, type RequestHandler } from 'express';
+import { getAllConfigs, getConfig } from '../crudtable/registry.js';
+import { loadUserPermissions } from '../services/access.js';
+import type { McpCallUser } from '../mcp/contextSynth.js';
+import { apiCallRateLimiter } from '../utils/rateLimiter.js';
+import { writeAuditRow } from '../mcp/audit.js';
+import { McpToolError } from '../mcp/errors.js';
+import type { McpOp } from '../mcp/schemaBuilder.js';
+import type { CRUDTableConfig, MCPScopeParam } from '../crudtable/types.js';
+import type { McpCallToolResult } from '../mcp/errors.js';
+import {
+  handleApiList,
+  handleApiRead,
+  handleApiCreate,
+  handleApiUpdate,
+  handleApiDelete,
+  apiResultFromThrown,
+  type ApiResult,
+} from './handlers.js';
+
+// ============================================
+// User resolution
+// ============================================
+
+async function resolveUser(req: Request): Promise<McpCallUser> {
+  const auth = req.auth!;
+  const extra = auth.extra as { userId?: unknown; username?: unknown; jti?: unknown } | undefined;
+  const userId = Number(extra?.userId ?? NaN);
+  const username = String(extra?.username ?? '');
+  const jtiRaw = extra?.jti;
+
+  const { isAdminForUser } = await import('../mcp/oauth/userFacts.js');
+  const [isAdmin, permissions] = await Promise.all([
+    isAdminForUser(userId),
+    loadUserPermissions(userId),
+  ]);
+
+  return {
+    userId,
+    username,
+    isAdmin,
+    permissions: permissions as Set<string>,
+    clientId: auth.clientId,
+    jti: typeof jtiRaw === 'string' ? jtiRaw : undefined,
+  };
+}
+
+// ============================================
+// Scope input resolution
+// ============================================
+
+function coerceScopeParam(raw: unknown, type: 'string' | 'number' | 'boolean'): unknown {
+  if (typeof raw !== 'string') return raw;
+  switch (type) {
+    case 'number': return Number(raw);
+    case 'boolean': return raw === 'true' || raw === '1';
+    default: return raw;
+  }
+}
+
+function buildScopeInput(
+  config: CRUDTableConfig,
+  query: Record<string, unknown>,
+  user: McpCallUser
+): Record<string, unknown> {
+  const scope: Record<string, unknown> = {};
+  for (const p of config.api?.scope ?? []) {
+    if (p.injectFromAuth) {
+      if (p.injectFromAuth === 'userId') scope[p.name] = user.userId;
+    } else {
+      const raw = query[p.name];
+      if (raw !== undefined) {
+        scope[p.name] = coerceScopeParam(raw, p.type);
+      }
+    }
+  }
+  return scope;
+}
+
+// ============================================
+// Operation enabled check
+// ============================================
+
+function isOpEnabled(config: CRUDTableConfig, op: McpOp): boolean {
+  const entry = config.api?.operations?.[op];
+  return entry === true || (typeof entry === 'object' && entry !== null);
+}
+
+// ============================================
+// Rate limiter middleware
+// ============================================
+
+function makeRateLimitMiddleware(): RequestHandler {
+  return (req: Request, res: Response, next: () => void): void => {
+    const key = req.auth?.clientId ?? req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+    if (apiCallRateLimiter.check(`api:${key}`)) {
+      next();
+      return;
+    }
+    res.setHeader('Retry-After', '60');
+    res.status(429).json({
+      error: { code: 'rate_limited', message: 'Rate limit exceeded' },
+    });
+  };
+}
+
+// ============================================
+// Send helper
+// ============================================
+
+function sendResult(res: Response, result: ApiResult): void {
+  if (result.status === 204 || result.body === null) {
+    res.status(204).end();
+    return;
+  }
+  res.status(result.status).json(result.body);
+}
+
+// ============================================
+// Audit helper
+// ============================================
+
+function auditResult(
+  isError: boolean,
+  errorCode?: string | null
+): McpCallToolResult {
+  return {
+    content: [],
+    isError,
+    ...(isError ? { structuredContent: { error: { code: errorCode ?? 'internal_error' } } } : {}),
+  };
+}
+
+// ============================================
+// Router factory
+// ============================================
+
+export interface ApiRouterOptions {
+  bearerAuth: RequestHandler;
+  debug?: boolean;
+}
+
+export function buildApiRouter({ bearerAuth, debug = false }: ApiRouterOptions): Router {
+  const router = Router();
+  const rateLimit = makeRateLimitMiddleware();
+
+  // -------- GET /api — discovery --------
+  router.get('/', bearerAuth, (_req: Request, res: Response) => {
+    const resources = getAllConfigs()
+      .filter((c) => c.api)
+      .map((c) => ({
+        id: c.id,
+        name: c.api!.name ?? c.id,
+        description: c.api!.description,
+        operations: Object.entries(c.api!.operations ?? {})
+          .filter(([, v]) => v === true || (typeof v === 'object' && v !== null))
+          .map(([op]) => op),
+        // Omit injectFromAuth params — callers don't need to know about them.
+        scope: (c.api!.scope ?? [])
+          .filter((p: MCPScopeParam) => !p.injectFromAuth)
+          .map((p: MCPScopeParam) => ({
+            name: p.name,
+            type: p.type,
+            required: p.required,
+            description: p.description,
+          })),
+      }));
+    res.json({ resources });
+  });
+
+  // -------- GET /api/:configId — list --------
+  router.get('/:configId', bearerAuth, rateLimit, async (req: Request, res: Response) => {
+    const config = getConfig(req.params.configId as string);
+    if (!config?.api) {
+      res.status(404).json({ error: { code: 'not_found', message: `Resource '${req.params.configId}' not found.` } });
+      return;
+    }
+    if (!isOpEnabled(config, 'list')) {
+      res.status(405).json({ error: { code: 'unsupported_operation', message: 'list is not enabled for this resource.' } });
+      return;
+    }
+    const startedAtMs = Date.now();
+    let user: McpCallUser | undefined;
+    let result: ApiResult;
+    try {
+      user = await resolveUser(req);
+      const scopeInput = buildScopeInput(config, req.query as Record<string, unknown>, user);
+      result = await handleApiList({ config, scopeInput, user, query: req.query as Record<string, unknown> });
+    } catch (err) {
+      result = apiResultFromThrown(err, debug);
+    }
+    sendResult(res, result);
+    if (user) {
+      void writeAuditRow({
+        configId: config.id,
+        toolName: `REST:${config.id}.list`,
+        op: 'list',
+        user,
+        input: req.query,
+        result: auditResult(result.status >= 400, result.status >= 400 ? (result.body as Record<string, unknown>)?.error as string : null),
+        startedAtMs,
+        source: 'api',
+      });
+    }
+  });
+
+  // -------- GET /api/:configId/:id — read --------
+  router.get('/:configId/:id', bearerAuth, rateLimit, async (req: Request, res: Response) => {
+    const config = getConfig(req.params.configId as string);
+    if (!config?.api) {
+      res.status(404).json({ error: { code: 'not_found', message: `Resource '${req.params.configId}' not found.` } });
+      return;
+    }
+    if (!isOpEnabled(config, 'read')) {
+      res.status(405).json({ error: { code: 'unsupported_operation', message: 'read is not enabled for this resource.' } });
+      return;
+    }
+    const id = Number(req.params.id);
+    if (isNaN(id)) {
+      res.status(400).json({ error: { code: 'validation_failed', message: 'id must be a number.' } });
+      return;
+    }
+    const startedAtMs = Date.now();
+    let user: McpCallUser | undefined;
+    let result: ApiResult;
+    try {
+      user = await resolveUser(req);
+      const scopeInput = buildScopeInput(config, req.query as Record<string, unknown>, user);
+      result = await handleApiRead({ config, scopeInput, user, id });
+    } catch (err) {
+      result = apiResultFromThrown(err, debug);
+    }
+    sendResult(res, result);
+    if (user) {
+      void writeAuditRow({
+        configId: config.id,
+        toolName: `REST:${config.id}.read`,
+        op: 'read',
+        user,
+        input: { id, ...req.query },
+        result: auditResult(result.status >= 400),
+        startedAtMs,
+        source: 'api',
+      });
+    }
+  });
+
+  // -------- POST /api/:configId — create --------
+  router.post('/:configId', bearerAuth, rateLimit, async (req: Request, res: Response) => {
+    const config = getConfig(req.params.configId as string);
+    if (!config?.api) {
+      res.status(404).json({ error: { code: 'not_found', message: `Resource '${req.params.configId}' not found.` } });
+      return;
+    }
+    if (!isOpEnabled(config, 'create')) {
+      res.status(405).json({ error: { code: 'unsupported_operation', message: 'create is not enabled for this resource.' } });
+      return;
+    }
+    const startedAtMs = Date.now();
+    let user: McpCallUser | undefined;
+    let result: ApiResult;
+    try {
+      user = await resolveUser(req);
+      const scopeInput = buildScopeInput(config, req.query as Record<string, unknown>, user);
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      result = await handleApiCreate({ config, scopeInput, user, body });
+    } catch (err) {
+      result = apiResultFromThrown(err, debug);
+    }
+    sendResult(res, result);
+    if (user) {
+      void writeAuditRow({
+        configId: config.id,
+        toolName: `REST:${config.id}.create`,
+        op: 'create',
+        user,
+        input: req.body,
+        result: auditResult(result.status >= 400),
+        startedAtMs,
+        source: 'api',
+      });
+    }
+  });
+
+  // -------- PUT /api/:configId/:id — update --------
+  router.put('/:configId/:id', bearerAuth, rateLimit, async (req: Request, res: Response) => {
+    const config = getConfig(req.params.configId as string);
+    if (!config?.api) {
+      res.status(404).json({ error: { code: 'not_found', message: `Resource '${req.params.configId}' not found.` } });
+      return;
+    }
+    if (!isOpEnabled(config, 'update')) {
+      res.status(405).json({ error: { code: 'unsupported_operation', message: 'update is not enabled for this resource.' } });
+      return;
+    }
+    const id = Number(req.params.id);
+    if (isNaN(id)) {
+      res.status(400).json({ error: { code: 'validation_failed', message: 'id must be a number.' } });
+      return;
+    }
+    const startedAtMs = Date.now();
+    let user: McpCallUser | undefined;
+    let result: ApiResult;
+    try {
+      user = await resolveUser(req);
+      const scopeInput = buildScopeInput(config, req.query as Record<string, unknown>, user);
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      result = await handleApiUpdate({ config, scopeInput, user, id, body });
+    } catch (err) {
+      result = apiResultFromThrown(err, debug);
+    }
+    sendResult(res, result);
+    if (user) {
+      void writeAuditRow({
+        configId: config.id,
+        toolName: `REST:${config.id}.update`,
+        op: 'update',
+        user,
+        input: { id, ...req.body },
+        result: auditResult(result.status >= 400),
+        startedAtMs,
+        source: 'api',
+      });
+    }
+  });
+
+  // -------- DELETE /api/:configId/:id — delete --------
+  router.delete('/:configId/:id', bearerAuth, rateLimit, async (req: Request, res: Response) => {
+    const config = getConfig(req.params.configId as string);
+    if (!config?.api) {
+      res.status(404).json({ error: { code: 'not_found', message: `Resource '${req.params.configId}' not found.` } });
+      return;
+    }
+    if (!isOpEnabled(config, 'delete')) {
+      res.status(405).json({ error: { code: 'unsupported_operation', message: 'delete is not enabled for this resource.' } });
+      return;
+    }
+    const id = Number(req.params.id);
+    if (isNaN(id)) {
+      res.status(400).json({ error: { code: 'validation_failed', message: 'id must be a number.' } });
+      return;
+    }
+    const startedAtMs = Date.now();
+    let user: McpCallUser | undefined;
+    let result: ApiResult;
+    try {
+      user = await resolveUser(req);
+      const scopeInput = buildScopeInput(config, req.query as Record<string, unknown>, user);
+      result = await handleApiDelete({ config, scopeInput, user, id });
+    } catch (err) {
+      result = apiResultFromThrown(err, debug);
+    }
+    sendResult(res, result);
+    if (user) {
+      void writeAuditRow({
+        configId: config.id,
+        toolName: `REST:${config.id}.delete`,
+        op: 'delete',
+        user,
+        input: { id },
+        result: auditResult(result.status >= 400),
+        startedAtMs,
+        source: 'api',
+      });
+    }
+  });
+
+  return router;
+}

--- a/server/src/configs/mcpAuditConfig.ts
+++ b/server/src/configs/mcpAuditConfig.ts
@@ -95,15 +95,23 @@ export const mcpAuditConfig: CRUDTableConfig = {
         cellRenderer: (r) => String(r.error_code ?? ''),
       },
     },
+    source: {
+      field: 'source',
+      label: 'Src',
+      length: 4,
+      column: {
+        width: 4,
+        cellRenderer: (r) => String(r.source ?? 'mcp'),
+      },
+    },
   },
 
   columnBuilder: [
     'created_at',
     'username',
-   
     'tool_name',
     'action',
-    'client_id',
+    'source',
     'ok',
     'duration_ms',
     'error_code',

--- a/server/src/configs/timeRegV2.ts
+++ b/server/src/configs/timeRegV2.ts
@@ -204,6 +204,45 @@ export const timeRegV2Config: CRUDTableConfig = {
   // their own time entries. `dayId` is derived server-side inside the
   // synthesized context.
 
+  // ============================================
+  // REST API exposure
+  // ============================================
+  //
+  // Exposes the same five operations as MCP at /api/timereg_v2. Auth uses the
+  // same OAuth 2.1 Bearer tokens. `userId` is injected from the token; `date`
+  // must be supplied as a query param (e.g. ?date=2026-04-23).
+  //
+  // List / create:  GET|POST /api/timereg_v2?date=YYYY-MM-DD
+  // Read/update/delete: GET|PUT|DELETE /api/timereg_v2/:id
+
+  api: {
+    name: 'timereg',
+    description:
+      'Time registration entries for the authenticated user on a given workday.',
+    operations: {
+      list: true,
+      read: true,
+      create: true,
+      update: true,
+      delete: true,
+    },
+    scope: [
+      {
+        name: 'userId',
+        type: 'number',
+        required: true,
+        description: 'Injected from the Bearer token — never a request param.',
+        injectFromAuth: 'userId',
+      },
+      {
+        name: 'date',
+        type: 'string',
+        required: true,
+        description: 'Workday in YYYY-MM-DD format. Pass as a query param.',
+      },
+    ],
+  },
+
   mcp: {
     name: 'timereg',
     description:

--- a/server/src/crudtable/registry.ts
+++ b/server/src/crudtable/registry.ts
@@ -1,7 +1,7 @@
 // CRUDTable Registry
 // Stores configs and derives screen IDs
 
-import type { CRUDTableConfig, MCPConfig } from './types.js';
+import type { CRUDTableConfig, MCPConfig, APIConfig } from './types.js';
 
 const configs = new Map<string, CRUDTableConfig>();
 
@@ -20,13 +20,16 @@ export function deleteConfirmScreenId(configId: string): string {
 
 /**
  * Register a CRUDTable config. Throws a clear startup error if the config is
- * malformed — in particular, if its optional `mcp` block is inconsistent with
- * the available services. Catching this at registration time is the only way
- * to prevent agents seeing broken tools.
+ * malformed — in particular, if its optional `mcp` or `api` blocks are
+ * inconsistent with the available services. Catching this at registration time
+ * is the only way to prevent broken tools or endpoints from being exposed.
  */
 export function registerConfig(config: CRUDTableConfig): void {
   if (config.mcp) {
     validateMcpConfig(config);
+  }
+  if (config.api) {
+    validateApiConfig(config);
   }
   configs.set(config.id, config);
 }
@@ -92,6 +95,83 @@ function validateMcpConfig(config: CRUDTableConfig): void {
   if (mcp.scope) {
     const seen = new Set<string>();
     for (const p of mcp.scope) {
+      if (!p.name || !p.type || !p.description) {
+        throw new Error(
+          `${ctx}.scope entries must have name, type, and description set ` +
+          `(offending entry: ${JSON.stringify(p)}).`
+        );
+      }
+      if (seen.has(p.name)) {
+        throw new Error(`${ctx}.scope has duplicate parameter name "${p.name}".`);
+      }
+      seen.add(p.name);
+    }
+  }
+}
+
+// Every API-exposable operation on a CRUDTableConfig maps 1:1 to a service name.
+const API_OP_SERVICES = ['list', 'read', 'create', 'update', 'delete'] as const;
+type ApiOpName = (typeof API_OP_SERVICES)[number];
+
+function isApiOperationEnabled(
+  operations: APIConfig['operations'],
+  op: ApiOpName
+): boolean {
+  if (!operations) return false;
+  const value = operations[op];
+  return value === true || (typeof value === 'object' && value !== null);
+}
+
+/**
+ * Enforce the invariants documented on {@link APIConfig}. Runs at
+ * `registerConfig` time so misconfigurations surface during server startup.
+ */
+function validateApiConfig(config: CRUDTableConfig): void {
+  const api = config.api!;
+  const ctx = `CRUDTableConfig "${config.id}".api`;
+
+  if (!api.operations || typeof api.operations !== 'object') {
+    throw new Error(`${ctx}: operations object is required.`);
+  }
+
+  const enabled = API_OP_SERVICES.filter((op) => isApiOperationEnabled(api.operations, op));
+  if (enabled.length === 0) {
+    throw new Error(
+      `${ctx}: at least one entry in operations must be enabled; remove the ` +
+      `api block entirely if you don't want to expose anything.`
+    );
+  }
+
+  for (const op of enabled) {
+    const serviceCall = config.services[op];
+    if (!serviceCall) {
+      throw new Error(
+        `${ctx}.operations.${op} is enabled but services.${op} is missing. ` +
+        `Either define the service or remove the operation from the api block.`
+      );
+    }
+    if (typeof serviceCall.method !== 'string' || !serviceCall.method) {
+      throw new Error(
+        `${ctx}.operations.${op} is enabled but services.${op}.method is not a non-empty string.`
+      );
+    }
+  }
+
+  // update and delete require read to pre-fetch the existing record.
+  if (
+    (isApiOperationEnabled(api.operations, 'update') ||
+      isApiOperationEnabled(api.operations, 'delete')) &&
+    !config.services.read
+  ) {
+    throw new Error(
+      `${ctx}: update and delete operations require services.read to be defined ` +
+      `(used to pre-fetch the record before mutation).`
+    );
+  }
+
+  if (api.scope) {
+    const seen = new Set<string>();
+    for (const p of api.scope) {
       if (!p.name || !p.type || !p.description) {
         throw new Error(
           `${ctx}.scope entries must have name, type, and description set ` +

--- a/server/src/crudtable/types.ts
+++ b/server/src/crudtable/types.ts
@@ -342,6 +342,50 @@ export interface MCPConfig {
   };
 }
 
+/**
+ * Per-operation override inside {@link APIConfig.operations}. Mirrors
+ * {@link MCPOperationOverride} for the REST API layer.
+ */
+export interface APIOperationConfig {
+  description?: string;
+  requirePermission?: string;
+}
+
+/**
+ * REST API exposure block for a {@link CRUDTableConfig}.
+ *
+ * Presence of this block is the opt-in signal. A config without `api` is never
+ * exposed via REST. Routes are mounted at `/api/{name ?? id}[/{id}]` on the
+ * MCP Express app (port 3002). Auth uses the same OAuth 2.1 Bearer tokens as MCP.
+ *
+ * RBAC is enforced identically to MCP: config.requirePermission →
+ * services[op].requirePermission → api.operations[op].requirePermission.
+ *
+ * Scope params with `injectFromAuth` are server-injected from the Bearer token
+ * and never accepted from the request — same pattern as {@link MCPScopeParam}.
+ */
+export interface APIConfig {
+  /**
+   * URL path segment for this resource. Defaults to `config.id` when absent.
+   * Must be URL-safe (lowercase-snake recommended).
+   */
+  name?: string;
+
+  description?: string;
+
+  operations?: {
+    list?:   boolean | APIOperationConfig;
+    read?:   boolean | APIOperationConfig;
+    create?: boolean | APIOperationConfig;
+    update?: boolean | APIOperationConfig;
+    delete?: boolean | APIOperationConfig;
+  };
+
+  /** Scope params injected into `ctx.input` for every request. Params with
+   * `injectFromAuth` are server-injected — never accepted from callers. */
+  scope?: MCPScopeParam[];
+}
+
 // Main CRUDTable config
 export interface CRUDTableConfig {
   id: string;
@@ -409,4 +453,14 @@ export interface CRUDTableConfig {
    * `services` and that `mcp.description` is present.
    */
   mcp?: MCPConfig;
+
+  /**
+   * Opt this config into the REST API layer, exposing CRUD endpoints at
+   * `/api/{api.name ?? id}[/{id}]`. Absent = not exposed at all.
+   *
+   * See {@link APIConfig} for the full shape. The registry validates at load
+   * time that any enabled operation has a corresponding `ServiceCall` on
+   * `services`.
+   */
+  api?: APIConfig;
 }

--- a/server/src/db/migrations/0006_freezing_spacker_dave.sql
+++ b/server/src/db/migrations/0006_freezing_spacker_dave.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "mcp_audit_log" ADD COLUMN "source" varchar(8) DEFAULT 'mcp' NOT NULL;

--- a/server/src/db/migrations/meta/0006_snapshot.json
+++ b/server/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1492 @@
+{
+  "id": "ebc429be-fa3f-45de-9dda-3b4207b85671",
+  "prevId": "765e2978-3431-447c-8efd-3aaf5c31e806",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'as500'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jti": {
+          "name": "jti",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_auth_tokens_token": {
+          "name": "idx_auth_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_tokens_access_token": {
+          "name": "idx_auth_tokens_access_token",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"auth_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_tokens_refresh_token": {
+          "name": "idx_auth_tokens_refresh_token",
+          "columns": [
+            {
+              "expression": "refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"auth_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_tokens_user_id": {
+          "name": "idx_auth_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_tokens_expires_at": {
+          "name": "idx_auth_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_tokens_user_device": {
+          "name": "idx_auth_tokens_user_device",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"auth_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_tokens_kind_jti": {
+          "name": "idx_auth_tokens_kind_jti",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "jti",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_tokens\".\"jti\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_tokens_client_id": {
+          "name": "idx_auth_tokens_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"auth_tokens\".\"client_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_tokens_token_unique": {
+          "name": "auth_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "auth_tokens_access_token_unique": {
+          "name": "auth_tokens_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_tokens_refresh_token_unique": {
+          "name": "auth_tokens_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.day_items": {
+      "name": "day_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day_id": {
+          "name": "day_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_hour": {
+          "name": "end_hour",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jiratask": {
+          "name": "jiratask",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rowsum": {
+          "name": "rowsum",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "day_items_day_id_days_id_fk": {
+          "name": "day_items_day_id_days_id_fk",
+          "tableFrom": "day_items",
+          "tableTo": "days",
+          "columnsFrom": [
+            "day_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.days": {
+      "name": "days",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workday": {
+          "name": "workday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daysum": {
+          "name": "daysum",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_user_id_users_id_fk": {
+          "name": "days_user_id_users_id_fk",
+          "tableFrom": "days",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "days_user_id_workday_unique": {
+          "name": "days_user_id_workday_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workday"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_permissions": {
+      "name": "group_permissions",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_key": {
+          "name": "permission_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_permissions_group_id_groups_id_fk": {
+          "name": "group_permissions_group_id_groups_id_fk",
+          "tableFrom": "group_permissions",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_permissions_permission_key_permissions_key_fk": {
+          "name": "group_permissions_permission_key_permissions_key_fk",
+          "tableFrom": "group_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_permissions_group_id_permission_key_pk": {
+          "name": "group_permissions_group_id_permission_key_pk",
+          "columns": [
+            "group_id",
+            "permission_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_name_unique": {
+          "name": "groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_hash": {
+          "name": "params_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mcp'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_log_created_at": {
+          "name": "idx_mcp_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_client_id": {
+          "name": "idx_mcp_audit_log_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_user_id": {
+          "name": "idx_mcp_audit_log_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_config_id": {
+          "name": "idx_mcp_audit_log_config_id",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mods": {
+      "name": "mods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "motorcycle_id": {
+          "name": "motorcycle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_date": {
+          "name": "installed_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mods_motorcycle_id": {
+          "name": "idx_mods_motorcycle_id",
+          "columns": [
+            {
+              "expression": "motorcycle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mods_motorcycle_id_motorcycles_id_fk": {
+          "name": "mods_motorcycle_id_motorcycles_id_fk",
+          "tableFrom": "mods",
+          "tableTo": "motorcycles",
+          "columnsFrom": [
+            "motorcycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.motorcycles": {
+      "name": "motorcycles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sell_date": {
+          "name": "sell_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "odometer_km": {
+          "name": "odometer_km",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine_cc": {
+          "name": "engine_cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_motorcycles_user_id": {
+          "name": "idx_motorcycles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "motorcycles_user_id_users_id_fk": {
+          "name": "motorcycles_user_id_users_id_fk",
+          "tableFrom": "motorcycles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_consents_user_client": {
+          "name": "idx_oauth_consents_user_client",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_client_id_oauth_clients_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_key": {
+          "name": "permission_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_permission_key_permissions_key_fk": {
+          "name": "role_permissions_permission_key_permissions_key_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_permission_key_pk": {
+          "name": "role_permissions_role_permission_key_pk",
+          "columns": [
+            "role",
+            "permission_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services_performed": {
+      "name": "services_performed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "motorcycle_id": {
+          "name": "motorcycle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_type": {
+          "name": "service_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_date": {
+          "name": "service_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "odometer_km": {
+          "name": "odometer_km",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop": {
+          "name": "shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_services_performed_motorcycle_id": {
+          "name": "idx_services_performed_motorcycle_id",
+          "columns": [
+            {
+              "expression": "motorcycle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_performed_motorcycle_id_motorcycles_id_fk": {
+          "name": "services_performed_motorcycle_id_motorcycles_id_fk",
+          "tableFrom": "services_performed",
+          "tableTo": "motorcycles",
+          "columnsFrom": [
+            "motorcycle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_groups_user_id_users_id_fk": {
+          "name": "user_groups_user_id_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permissions": {
+      "name": "user_permissions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_key": {
+          "name": "permission_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_permissions_user_id_users_id_fk": {
+          "name": "user_permissions_user_id_users_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_permissions_permission_key_permissions_key_fk": {
+          "name": "user_permissions_permission_key_permissions_key_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_permissions_user_id_permission_key_pk": {
+          "name": "user_permissions_user_id_permission_key_pk",
+          "columns": [
+            "user_id",
+            "permission_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "superuser",
+        "aiagent",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776937861176,
       "tag": "0005_wandering_ender_wiggin",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776960045880,
+      "tag": "0006_freezing_spacker_dave",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -262,6 +262,8 @@ export const mcpAuditLog = pgTable('mcp_audit_log', {
   ok: boolean('ok').notNull(),
   error_code: varchar('error_code', { length: 64 }),
   duration_ms: integer('duration_ms').notNull(),
+  // 'mcp' = MCP tool call, 'api' = REST API call
+  source: varchar('source', { length: 8 }).default('mcp').notNull(),
   created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 }, (t) => [
   index('idx_mcp_audit_log_created_at').on(t.created_at),

--- a/server/src/mcp/audit.ts
+++ b/server/src/mcp/audit.ts
@@ -25,6 +25,8 @@ export interface AuditCallArgs {
   input: unknown;
   result: McpCallToolResult;
   startedAtMs: number;
+  /** Identifies the access path for this call. Defaults to 'mcp'. */
+  source?: 'mcp' | 'api';
 }
 
 /**
@@ -41,7 +43,7 @@ function extractErrorCode(result: McpCallToolResult): string | null {
 }
 
 export async function writeAuditRow(args: AuditCallArgs): Promise<void> {
-  const { configId, toolName, op, user, input, result, startedAtMs } = args;
+  const { configId, toolName, op, user, input, result, startedAtMs, source } = args;
   const durationMs = Math.max(0, Date.now() - startedAtMs);
   const errorCode = extractErrorCode(result);
   try {
@@ -55,6 +57,7 @@ export async function writeAuditRow(args: AuditCallArgs): Promise<void> {
       ok: !result.isError,
       error_code: errorCode,
       duration_ms: durationMs,
+      source: source ?? 'mcp',
     });
   } catch (err) {
     console.error('[mcp-audit] failed to write audit row:', err);

--- a/server/src/mcp/contextSynth.ts
+++ b/server/src/mcp/contextSynth.ts
@@ -54,7 +54,7 @@ function valueToString(v: unknown): string {
 
 /**
  * Split the validated tool input into `(scope, body)`:
- *   - `scope` = values for keys declared on `mcp.scope`
+ *   - `scope` = values for keys declared on scope params
  *   - `body`  = everything else (form fields, `id`, `limit`, etc.)
  *
  * Scope is destined for `ctx.input`, the rest for wherever the handler wants
@@ -63,12 +63,16 @@ function valueToString(v: unknown): string {
  * Note: params marked `injectFromAuth` are NOT in the Zod schema so they will
  * never appear in `input`. Their values are injected separately inside
  * `synthesizeContext` using `McpCallUser`.
+ *
+ * @param scopeParamsOverride - When provided, use this instead of `config.mcp?.scope`.
+ *   REST API handlers pass `config.api?.scope` here.
  */
 export function splitScope(
   config: CRUDTableConfig,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  scopeParamsOverride?: MCPScopeParam[]
 ): { scope: Record<string, unknown>; body: Record<string, unknown> } {
-  const scopeParams = config.mcp?.scope ?? [];
+  const scopeParams = scopeParamsOverride ?? config.mcp?.scope ?? [];
   const scopeKeys = new Set(
     scopeParams.filter((p: MCPScopeParam) => !p.injectFromAuth).map((p: MCPScopeParam) => p.name)
   );
@@ -89,13 +93,17 @@ export function splitScope(
  * Currently only `injectFromAuth: 'userId'` is supported, mapping to
  * `McpCallUser.userId` (the integer id that corresponds to
  * `auth_tokens.user_id` for the active OAuth session).
+ *
+ * @param scopeParamsOverride - When provided, use this instead of `config.mcp?.scope`.
+ *   REST API handlers pass `config.api?.scope` here.
  */
 export function buildInjectedScope(
   config: CRUDTableConfig,
-  user: McpCallUser
+  user: McpCallUser,
+  scopeParamsOverride?: MCPScopeParam[]
 ): Record<string, unknown> {
   const injected: Record<string, unknown> = {};
-  for (const p of config.mcp?.scope ?? []) {
+  for (const p of scopeParamsOverride ?? config.mcp?.scope ?? []) {
     if (!p.injectFromAuth) continue;
     switch (p.injectFromAuth) {
       case 'userId':
@@ -115,6 +123,12 @@ export interface SynthContextArgs {
   /** For `delete`: the pre-fetched record being deleted. */
   deleteRecord?: Record<string, unknown> | null;
   user: McpCallUser;
+  /**
+   * Override the scope params used to split input into (scope, body) and to
+   * inject server-side values. MCP callers omit this (defaults to
+   * `config.mcp?.scope`). REST API callers pass `config.api?.scope`.
+   */
+  scopeParams?: MCPScopeParam[];
 }
 
 /**
@@ -147,13 +161,14 @@ export function synthesizeContext({
   editRecord,
   deleteRecord,
   user,
+  scopeParams,
 }: SynthContextArgs): CRUDContext {
-  const { scope, body } = splitScope(_config, input);
+  const { scope, body } = splitScope(_config, input, scopeParams);
 
   // Merge agent-supplied scope first, then overwrite with server-injected
   // values so agents can never smuggle in their own userId (or any other
   // injectFromAuth param) even if they somehow include the key.
-  const injected = buildInjectedScope(_config, user);
+  const injected = buildInjectedScope(_config, user, scopeParams);
   const ctxInput: Record<string, unknown> = { ...scope, ...injected };
   const values: Record<string, string> = {};
 

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -16,6 +16,10 @@
 //                                                      MCP Streamable HTTP
 //                                                      transport)
 //   GET  /mcp/health                                  (no auth — liveness)
+//   POST /api/auth/token                              (first-party login —
+//                                                      username+password → tokens)
+//   POST /api/auth/refresh                            (rotate refresh token)
+//   POST /api/auth/revoke                             (logout / revoke token)
 //
 // Auth posture:
 //   `/mcp` is now protected by `requireBearerAuth`. Unauthenticated calls
@@ -32,6 +36,8 @@ import {
 } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import { buildMcpServer } from './transport.js';
+import { buildApiRouter } from '../api/index.js';
+import { buildAuthRouter } from '../api/auth.js';
 import { buildAs500OAuthProvider, issueAuthorizationCodeAfterConsent } from './oauth/provider.js';
 import { initJwtSecret } from './oauth/tokens.js';
 import { hasLiveConsent, recordConsent } from './oauth/store.js';
@@ -314,6 +320,13 @@ export function buildMcpApp(opts: McpAppOptions = {}): Express {
   };
 
   app.post('/mcp', bearerAuth, rateLimit, handleMcp);
+
+  // -------- First-party auth (no bearer — credential exchange) --------
+  // Must be mounted BEFORE the general /api router so /api/auth/* is matched here.
+  app.use('/api/auth', buildAuthRouter());
+
+  // -------- REST API (mounted at /api) --------
+  app.use('/api', buildApiRouter({ bearerAuth, debug: opts.debug }));
 
   const methodNotAllowed = (_req: Request, res: Response): void => {
     res.status(405).json({

--- a/server/src/mcp/toolHandlers.ts
+++ b/server/src/mcp/toolHandlers.ts
@@ -28,10 +28,10 @@ import {
 /**
  * Invoke `ServiceCall.service[method](ServiceCall.params(ctx))`. Mirrors the
  * same pattern CRUDTable's runtime uses (`server/src/crudtable/runtime.ts`)
- * so behaviour is identical whether the call originates from the terminal UI
- * or from an MCP agent.
+ * so behaviour is identical whether the call originates from the terminal UI,
+ * an MCP agent, or the REST API.
  */
-async function invokeServiceCall(
+export async function invokeServiceCall(
   sc: ServiceCall,
   ctx: CRUDContext
 ): Promise<unknown> {
@@ -54,15 +54,14 @@ async function invokeServiceCall(
 
 /**
  * Run every form validator declared on the config's field configs. Returns
- * all validation errors at once (never throws) so agents can fix the whole
- * input in a single round-trip rather than discovering errors one field at a
- * time.
+ * all validation errors at once (never throws) so callers can report the whole
+ * set in a single response rather than discovering errors one field at a time.
  *
  * Mirrors `server/src/crudtable/runtime.ts`'s validation pass — CRUDTable's
  * `validators` are `(ctx) => string | null`, so we run them against the
  * synthesized context.
  */
-function runValidators(
+export function runValidators(
   config: CRUDTableConfig,
   ctx: CRUDContext
 ): { name: string; message: string }[] {
@@ -87,7 +86,7 @@ function runValidators(
 // Helpers
 // ============================================
 
-function assertService(sc: ServiceCall | undefined, op: McpOp): asserts sc is ServiceCall {
+export function assertService(sc: ServiceCall | undefined, op: McpOp): asserts sc is ServiceCall {
   if (!sc) {
     throw new McpToolError(
       'unsupported_operation',

--- a/server/src/services/mcpAuditAdminService.ts
+++ b/server/src/services/mcpAuditAdminService.ts
@@ -17,6 +17,7 @@ export interface McpAuditRow {
   ok: boolean;
   error_code: string | null;
   duration_ms: number;
+  source: string;
 }
 
 const MAX_ROWS = 500;
@@ -35,6 +36,7 @@ export async function listMcpAudit(_params?: Record<string, unknown>): Promise<M
       ok: mcpAuditLog.ok,
       error_code: mcpAuditLog.error_code,
       duration_ms: mcpAuditLog.duration_ms,
+      source: mcpAuditLog.source,
     })
     .from(mcpAuditLog)
     .leftJoin(users, eq(users.id, mcpAuditLog.user_id))

--- a/server/src/utils/rateLimiter.ts
+++ b/server/src/utils/rateLimiter.ts
@@ -90,3 +90,14 @@ export const tokenRefreshRateLimiter = new RateLimiter(10, 60 * 60 * 1000); // 1
 // 120 req/min in prod, 600 in dev — a single registered client id is the key
 // when a bearer token is present; otherwise falls back to the client IP.
 export const mcpCallRateLimiter = new RateLimiter(isProduction ? 120 : 600, 60 * 1000);
+
+// Per-token limiter for the REST API `/api/*` endpoints. More permissive than
+// MCP since REST clients tend to make individual resource requests.
+// 300 req/min in prod, 600 in dev.
+export const apiCallRateLimiter = new RateLimiter(isProduction ? 300 : 600, 60 * 1000);
+
+// Per-IP limiter for the first-party `POST /api/auth/token` endpoint.
+// Slightly more generous than the WebSocket login limiter (10 vs 5) since
+// server-side apps legitimately need occasional automated logins on startup.
+// 10 attempts/min in prod, 100 in dev.
+export const directLoginRateLimiter = new RateLimiter(isProduction ? 10 : 100, 60 * 1000);


### PR DESCRIPTION
- Introduced a new REST API layer that exposes CRUDTable configurations as standard REST endpoints.
- Implemented authentication via Bearer tokens for first-party applications, allowing direct credential exchange for token issuance.
- Added comprehensive documentation for the REST API, including endpoint definitions, authentication flows, and error handling.
- Updated relevant files to integrate the new API functionality, ensuring consistent RBAC and audit logging across both REST and MCP surfaces.