### PR TITLE
docs: add core/app separation refactor plan and production setup guide

### DIFF
--- a/DOCS/PRODUCTION_SETUP.md
+++ b/DOCS/PRODUCTION_SETUP.md
@@ -1,0 +1,422 @@
+# AS500 Production Setup Guide
+
+Complete reference for deploying a new AS500 server instance from scratch.
+
+---
+
+## Architecture Overview
+
+```
+Internet → Caddy (HTTPS :443) → Node.js app (:3001, WebSocket + HTTP)
+                              → MCP OAuth server (:3002, HTTP — Caddy proxies /mcp)
+                              → PostgreSQL (:5432, internal only)
+```
+
+All services run as Docker containers. Caddy runs on the host and terminates TLS.
+
+---
+
+## Environment Variables
+
+### Quick Reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `DATABASE_URL` | **YES** | — | PostgreSQL connection string |
+| `POSTGRES_PASSWORD` | **YES** | — | Password for Docker Postgres service |
+| `AS500_MCP_JWT_SECRET` | **YES** | — | HS256 signing key for MCP tokens (≥32 chars) |
+| `MCP_PUBLIC_URL` | **YES** | — | Public HTTPS URL of the MCP endpoint |
+| `NODE_ENV` | recommended | `undefined` | Set to `production` |
+| `PORT` | no | `3001` | WebSocket / HTTP server port |
+| `MCP_PORT` | no | `3002` | MCP OAuth server port |
+| `MCP_ENABLED` | no | `true` | Set to `false` to disable MCP server |
+| `ADMIN_PASSWORD` | no | — | Initial seed password for FREDRIC admin account |
+| `JIRA_BASE_URL` | no | — | e.g. `https://your-org.atlassian.net` |
+| `JIRA_USER_EMAIL` | no | — | Jira account email for API auth |
+| `JIRA_API_TOKEN` | no | — | Jira API token (from Atlassian account settings) |
+
+---
+
+### Full Variable Descriptions
+
+#### `DATABASE_URL` — Required
+
+PostgreSQL connection string in URI format.
+
+```
+postgresql://USER:PASSWORD@HOST:PORT/DATABASE
+```
+
+Examples:
+```
+postgresql://as500:s3cr3t@localhost:5432/as500
+postgresql://as500:s3cr3t@postgres:5432/as500   # Docker service name
+```
+
+If set, this takes precedence over all `PG*` variables. For hosted databases (RDS, Heroku), the driver automatically enables SSL when the URL contains `amazonaws.com` or `heroku`.
+
+---
+
+#### `POSTGRES_PASSWORD` — Required (Docker deployments)
+
+The password used by the `postgres` Docker service. Must match the password in `DATABASE_URL`.
+
+Set this in a `.env` file at the project root so `docker-compose.prod.yml` can read it.
+
+---
+
+#### `AS500_MCP_JWT_SECRET` — Required in production
+
+HS256 signing key for MCP access tokens. Must be at least 32 characters.
+
+**Generate a secure value:**
+```bash
+openssl rand -base64 48
+```
+
+**Behaviour:**
+- Production: server refuses to start if unset or shorter than 32 chars.
+- Development: auto-generates a random secret per process (tokens do not survive restart — acceptable for dev).
+
+This value must remain stable across deployments. Rotating it invalidates all active MCP sessions.
+
+---
+
+#### `MCP_PUBLIC_URL` — Required in production
+
+The external HTTPS URL that MCP clients will use for OAuth discovery and token endpoints. Must match the URL advertised in `/.well-known/oauth-authorization-server`.
+
+```
+https://your-domain.com
+```
+
+Do **not** include a trailing slash or path suffix. The server appends `/mcp`, `/authorize`, `/token`, etc. internally.
+
+---
+
+#### `NODE_ENV`
+
+Set to `production` to:
+- Disable verbose error messages in MCP responses
+- Serve the compiled React SPA as static files from the same process
+- Apply stricter rate limits (5 login attempts/min, 10 token refreshes/hour)
+
+```
+NODE_ENV=production
+```
+
+---
+
+#### `PORT`
+
+WebSocket and HTTP server port. Default: `3001`.
+
+Only change this if port 3001 is unavailable. If changed, update the Caddy reverse proxy config to match.
+
+---
+
+#### `MCP_PORT`
+
+MCP OAuth server port. Default: `3002`.
+
+Only change this if port 3002 is unavailable. If changed, update the Caddy reverse proxy config to match.
+
+---
+
+#### `MCP_ENABLED`
+
+Set to `false` to disable the MCP server entirely. Useful for deployments that only expose the terminal interface.
+
+```
+MCP_ENABLED=false
+```
+
+---
+
+#### `ADMIN_PASSWORD`
+
+If set during database seeding, the initial `FREDRIC` admin account is created with this password instead of the default `fredric`.
+
+```bash
+docker compose -f docker-compose.prod.yml exec server npm run seed
+```
+
+Only relevant on first-time database initialisation. Has no effect if the user already exists.
+
+---
+
+#### `JIRA_BASE_URL`, `JIRA_USER_EMAIL`, `JIRA_API_TOKEN`
+
+Optional integration with Atlassian Jira for task lookup in time registration. All three must be set for the integration to work.
+
+```
+JIRA_BASE_URL=https://your-org.atlassian.net
+JIRA_USER_EMAIL=you@your-org.com
+JIRA_API_TOKEN=ATATT3xFfGF0...
+```
+
+Generate an API token at: https://id.atlassian.com/manage-profile/security/api-tokens
+
+---
+
+## Production `.env` Template
+
+Create `/var/www/AS500/.env` on the server with this template. Fill in all required values before first deployment.
+
+```bash
+# ==============================================================================
+# AS500 Production Environment
+# Generated: $(date +%Y-%m-%d)
+# ==============================================================================
+
+# --- Database -----------------------------------------------------------------
+# Connection string for PostgreSQL.
+DATABASE_URL=postgresql://as500:CHANGE_ME@postgres:5432/as500
+
+# Password for the Docker postgres service — must match DATABASE_URL above.
+POSTGRES_PASSWORD=CHANGE_ME
+
+# --- Security -----------------------------------------------------------------
+# HS256 signing key for MCP tokens. Generate with: openssl rand -base64 48
+# REQUIRED. Must be ≥32 chars. Rotating this invalidates all MCP sessions.
+AS500_MCP_JWT_SECRET=CHANGE_ME_openssl_rand_-base64_48
+
+# --- MCP / OAuth --------------------------------------------------------------
+# Public HTTPS URL of this server (no trailing slash). Used in OAuth discovery.
+MCP_PUBLIC_URL=https://your-domain.com
+
+# --- Runtime ------------------------------------------------------------------
+NODE_ENV=production
+
+# Optional: change only if ports 3001/3002 conflict with other services.
+# PORT=3001
+# MCP_PORT=3002
+
+# Optional: set to false to disable MCP server entirely.
+# MCP_ENABLED=false
+
+# --- Initial Seed (first deploy only) ----------------------------------------
+# If set, the FREDRIC admin account is seeded with this password.
+# Remove or leave blank after first deploy.
+# ADMIN_PASSWORD=CHANGE_ME
+
+# --- Jira Integration (optional) ---------------------------------------------
+# JIRA_BASE_URL=https://your-org.atlassian.net
+# JIRA_USER_EMAIL=you@your-org.com
+# JIRA_API_TOKEN=
+```
+
+---
+
+## Server Setup: Step by Step
+
+### Prerequisites
+
+- Ubuntu 22.04 LTS (or compatible Debian-based system)
+- Docker Engine 24+
+- Docker Compose plugin v2
+- Caddy 2.x installed on the host
+- A domain name with DNS A record pointing to the server IP
+
+### 1. Install Docker
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+# Log out and back in for group change to take effect
+```
+
+### 2. Install Caddy
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install caddy
+```
+
+### 3. Clone the Repository
+
+```bash
+sudo mkdir -p /var/www/AS500
+sudo chown $USER:$USER /var/www/AS500
+git clone git@github.com:fredric/as500.git /var/www/AS500
+cd /var/www/AS500
+```
+
+### 4. Create the `.env` File
+
+```bash
+cp /dev/stdin /var/www/AS500/.env << 'EOF'
+# Paste the template from the section above, with real values filled in
+EOF
+chmod 600 /var/www/AS500/.env
+```
+
+### 5. Configure Caddy
+
+Create `/etc/caddy/Caddyfile`:
+
+```caddy
+your-domain.com {
+    # Terminal WebSocket + static SPA
+    reverse_proxy [::1]:3001
+
+    # MCP endpoint — proxied to the OAuth server
+    handle /mcp* {
+        reverse_proxy [::1]:3002
+    }
+
+    # OAuth well-known + token endpoints
+    handle /.well-known/* {
+        reverse_proxy [::1]:3002
+    }
+    handle /register {
+        reverse_proxy [::1]:3002
+    }
+    handle /authorize* {
+        reverse_proxy [::1]:3002
+    }
+    handle /token {
+        reverse_proxy [::1]:3002
+    }
+    handle /revoke {
+        reverse_proxy [::1]:3002
+    }
+}
+```
+
+```bash
+sudo systemctl reload caddy
+sudo caddy validate --config /etc/caddy/Caddyfile
+```
+
+Caddy automatically provisions and renews a Let's Encrypt certificate for the domain.
+
+### 6. Build and Start
+
+```bash
+cd /var/www/AS500
+docker compose -f docker-compose.prod.yml build app
+docker compose -f docker-compose.prod.yml up -d
+```
+
+### 7. Seed the Database (first deploy only)
+
+```bash
+docker compose -f docker-compose.prod.yml exec server npm run seed
+```
+
+This creates the `FREDRIC` admin account. If `ADMIN_PASSWORD` is set in `.env`, that password is used; otherwise the default is `fredric` — change it immediately after login.
+
+### 8. Verify the Deployment
+
+```bash
+# Check container health
+docker compose -f docker-compose.prod.yml ps
+
+# Tail application logs
+docker compose -f docker-compose.prod.yml logs -f server
+
+# HTTP health check
+curl -I https://your-domain.com
+
+# MCP health check
+curl https://your-domain.com/mcp/health
+```
+
+---
+
+## Updating an Existing Deployment
+
+```bash
+cd /var/www/AS500
+git pull
+docker compose -f docker-compose.prod.yml build app
+docker compose -f docker-compose.prod.yml up -d app
+```
+
+Database migrations run automatically on server startup. No manual migration step needed.
+
+---
+
+## Backup and Restore
+
+### Backup
+
+```bash
+cd /var/www/AS500
+docker compose -f docker-compose.prod.yml exec server npm run backup-db
+# Creates a timestamped .sql file in server/data/
+```
+
+### Restore
+
+```bash
+docker compose -f docker-compose.prod.yml exec server npm run restore-db server/data/backup-YYYY-MM-DD.sql
+```
+
+---
+
+## Logs
+
+```bash
+# Live logs (all services)
+docker compose -f docker-compose.prod.yml logs -f
+
+# Application only
+docker compose -f docker-compose.prod.yml logs -f server
+
+# Filter for errors
+docker compose -f docker-compose.prod.yml logs server 2>&1 | grep -i error
+```
+
+---
+
+## Common Issues
+
+### Server starts but login fails
+
+Check that the database was seeded:
+```bash
+docker compose -f docker-compose.prod.yml exec postgres psql -U as500 -c "SELECT username FROM users;"
+```
+
+If the `users` table is empty, run the seed command (Step 7 above).
+
+### MCP tokens don't survive a restart
+
+`AS500_MCP_JWT_SECRET` is not set in `.env`, so a new random secret is generated on each startup. Set a stable value.
+
+### WebSocket connection refused
+
+Caddy is not proxying port 3001. Check that `[::1]:3001` is reachable from the host:
+```bash
+curl -s http://localhost:3001/health || echo "not reachable"
+```
+And verify the Caddy config has a `reverse_proxy [::1]:3001` line for the root path.
+
+### OAuth discovery returns wrong URLs
+
+`MCP_PUBLIC_URL` is set incorrectly. It must exactly match the external HTTPS URL of the server — no trailing slash, no `/mcp` suffix.
+
+### Caddy certificate provisioning fails
+
+Ensure port 80 and 443 are open in the firewall:
+```bash
+sudo ufw allow 80
+sudo ufw allow 443
+```
+And that the domain's DNS A record resolves to the correct server IP before starting Caddy.
+
+---
+
+## Security Checklist (before going live)
+
+- [ ] `AS500_MCP_JWT_SECRET` is at least 48 characters and unique to this deployment
+- [ ] `POSTGRES_PASSWORD` is a strong random password (not the default `as500`)
+- [ ] `ADMIN_PASSWORD` was set during seed and the default `fredric` password has been changed
+- [ ] `.env` file permissions are `600` (`chmod 600 .env`)
+- [ ] Ports 3001 and 3002 are not exposed to the internet (only Caddy on 80/443 is public)
+- [ ] `NODE_ENV=production` is set
+- [ ] MCP JWT secret rotation plan is documented (invalidates all MCP sessions)

--- a/DOCS/REFACTOR_SEPARATION.md
+++ b/DOCS/REFACTOR_SEPARATION.md
@@ -1,0 +1,582 @@
+# AS500 Core / App Separation Refactor
+
+## Goal
+
+Split AS500 into two distinct layers:
+
+- **`server/src/core/`** — The AS500 product. Auth, sessions, RBAC, CRUDTable runtime, MCP/OAuth, DSL renderer, built-in admin screens. Developers using AS500 as their backend **never modify files here**.
+- **`server/src/app/`** — The application built on top of AS500. Business-specific services, CRUDTable configs, DB table definitions, and menu items. This is where developers work.
+
+The separation is enforced by directory structure. There is no package boundary in this phase — that can be introduced later if needed.
+
+---
+
+## Before / After Directory Layout
+
+### Before (current mixed structure)
+
+```
+server/src/
+├── configs/          ← mixes system configs + app configs
+├── crudtable/
+├── db/
+│   └── schema.ts     ← mixes system tables + app tables
+├── dsl/
+├── mcp/
+├── menus/
+│   └── menuTree.ts   ← mixes admin nodes + app nodes in one static tree
+├── screens/
+├── services/         ← mixes system services + app services
+├── session/
+├── types/
+├── utils/
+└── index.ts
+```
+
+### After (separated)
+
+```
+server/src/
+├── core/                          ← AS500 product (never edited by app developers)
+│   ├── bootstrap.ts               ← NEW: starts core (registers core configs + admin menu)
+│   ├── configs/                   ← system-only CRUDTable configs
+│   │   ├── authTokensConfig.ts
+│   │   ├── mcpAuditConfig.ts
+│   │   ├── oauthClientsConfig.ts
+│   │   ├── roleDefaultsConfig.ts
+│   │   └── userMgmtConfig.ts
+│   ├── crudtable/                 ← runtime engine (unchanged)
+│   ├── db/
+│   │   ├── index.ts
+│   │   ├── migrate.ts
+│   │   ├── schema.ts              ← system tables only
+│   │   └── seed.ts
+│   ├── dsl/
+│   ├── mcp/
+│   ├── menus/
+│   │   ├── menuRegistry.ts        ← NEW: runtime menu assembly + app registration API
+│   │   ├── menuRuntime.ts         ← updated to call buildMenuTree() instead of static import
+│   │   └── menuTree.ts            ← trimmed to admin subtree + log off only
+│   ├── screens/
+│   ├── services/                  ← system services only
+│   │   ├── access.ts
+│   │   ├── auth.ts
+│   │   ├── authTokensAdminService.ts
+│   │   ├── mcpAuditAdminService.ts
+│   │   ├── oauthClientsAdminService.ts
+│   │   ├── roleDefaults.ts
+│   │   ├── roleDefaultsService.ts
+│   │   ├── userMgmt.ts
+│   │   └── userService.ts
+│   ├── session/
+│   ├── types/
+│   └── utils/
+│
+├── app/                           ← Application layer (this project's business code)
+│   ├── index.ts                   ← NEW: side-effect entry — registers configs + menu items
+│   ├── configs/                   ← app-specific CRUDTable configs
+│   │   ├── motorcyclesConfig.ts
+│   │   ├── modsConfig.ts
+│   │   ├── servicesPerformedConfig.ts
+│   │   └── timeRegV2.ts
+│   ├── db/
+│   │   └── schema.ts              ← app-specific tables only
+│   ├── menus/
+│   │   └── appMenu.ts             ← NEW: calls registerMenuItems() for app nodes
+│   └── services/
+│       ├── jiraTasks.ts
+│       ├── motorcycleService.ts
+│       ├── modsService.ts
+│       ├── servicesPerformedService.ts
+│       ├── timeReg.ts
+│       └── timeRegCrud.ts
+│
+└── index.ts                       ← entry point: import core bootstrap + app (unchanged shape)
+```
+
+---
+
+## Phases
+
+Work through each phase in order. Verify TypeScript compiles (`npm run typecheck` from project root) after each phase before moving to the next.
+
+---
+
+## Phase 1 — Create Directory Structure
+
+Create these empty directories. Do not move any files yet.
+
+```
+server/src/core/
+server/src/core/configs/
+server/src/core/db/
+server/src/core/crudtable/
+server/src/core/dsl/
+server/src/core/mcp/
+server/src/core/menus/
+server/src/core/screens/
+server/src/core/services/
+server/src/core/session/
+server/src/core/types/
+server/src/core/utils/
+server/src/app/
+server/src/app/configs/
+server/src/app/db/
+server/src/app/menus/
+server/src/app/services/
+```
+
+---
+
+## Phase 2 — Move Core Infrastructure (no logic changes)
+
+Move these files verbatim. Only update relative imports *within* these files to reflect their new depth.
+
+| Old path | New path |
+|---|---|
+| `server/src/crudtable/context.ts` | `server/src/core/crudtable/context.ts` |
+| `server/src/crudtable/registry.ts` | `server/src/core/crudtable/registry.ts` |
+| `server/src/crudtable/router.ts` | `server/src/core/crudtable/router.ts` |
+| `server/src/crudtable/runtime.ts` | `server/src/core/crudtable/runtime.ts` |
+| `server/src/crudtable/types.ts` | `server/src/core/crudtable/types.ts` |
+| `server/src/db/index.ts` | `server/src/core/db/index.ts` |
+| `server/src/db/migrate.ts` | `server/src/core/db/migrate.ts` |
+| `server/src/db/seed.ts` | `server/src/core/db/seed.ts` |
+| `server/src/dsl/index.ts` | `server/src/core/dsl/index.ts` |
+| `server/src/dsl/renderer.ts` | `server/src/core/dsl/renderer.ts` |
+| `server/src/dsl/types.ts` | `server/src/core/dsl/types.ts` |
+| `server/src/dsl/components/` (whole dir) | `server/src/core/dsl/components/` |
+| `server/src/mcp/` (whole dir) | `server/src/core/mcp/` |
+| `server/src/screens/login.ts` | `server/src/core/screens/login.ts` |
+| `server/src/screens/mainMenu.ts` | `server/src/core/screens/mainMenu.ts` |
+| `server/src/session/index.ts` | `server/src/core/session/index.ts` |
+| `server/src/types/index.ts` | `server/src/core/types/index.ts` |
+| `server/src/utils/rateLimiter.ts` | `server/src/core/utils/rateLimiter.ts` |
+
+**Import depth changes:** Files that were at `server/src/X/foo.ts` and imported `../db/index.js` are now at `server/src/core/X/foo.ts` — if `db` also moved to `core/db/`, the relative path `../db/index.js` is still correct (both are one level under `core/`). Verify case by case.
+
+---
+
+## Phase 3 — Move Core Services
+
+| Old path | New path |
+|---|---|
+| `server/src/services/access.ts` | `server/src/core/services/access.ts` |
+| `server/src/services/auth.ts` | `server/src/core/services/auth.ts` |
+| `server/src/services/authTokensAdminService.ts` | `server/src/core/services/authTokensAdminService.ts` |
+| `server/src/services/mcpAuditAdminService.ts` | `server/src/core/services/mcpAuditAdminService.ts` |
+| `server/src/services/oauthClientsAdminService.ts` | `server/src/core/services/oauthClientsAdminService.ts` |
+| `server/src/services/roleDefaults.ts` | `server/src/core/services/roleDefaults.ts` |
+| `server/src/services/roleDefaultsService.ts` | `server/src/core/services/roleDefaultsService.ts` |
+| `server/src/services/userMgmt.ts` | `server/src/core/services/userMgmt.ts` |
+| `server/src/services/userService.ts` | `server/src/core/services/userService.ts` |
+
+---
+
+## Phase 4 — Move Core Configs
+
+| Old path | New path |
+|---|---|
+| `server/src/configs/authTokensConfig.ts` | `server/src/core/configs/authTokensConfig.ts` |
+| `server/src/configs/mcpAuditConfig.ts` | `server/src/core/configs/mcpAuditConfig.ts` |
+| `server/src/configs/oauthClientsConfig.ts` | `server/src/core/configs/oauthClientsConfig.ts` |
+| `server/src/configs/roleDefaultsConfig.ts` | `server/src/core/configs/roleDefaultsConfig.ts` |
+| `server/src/configs/userMgmtConfig.ts` | `server/src/core/configs/userMgmtConfig.ts` |
+
+---
+
+## Phase 5 — Split the Schema
+
+### 5a. Move system tables to `core/db/schema.ts`
+
+Keep these tables in `server/src/core/db/schema.ts` (rename/move from existing `server/src/db/schema.ts`):
+
+- `users`
+- `auth_tokens`
+- `groups`
+- `user_groups`
+- `permissions`
+- `role_permissions`
+- `group_permissions`
+- `user_permissions`
+- `oauth_clients`
+- `oauth_consents`
+- `mcp_audit_log`
+
+### 5b. Create `app/db/schema.ts` with app tables
+
+Create `server/src/app/db/schema.ts` containing only:
+
+- `days`
+- `day_items`
+- `motorcycles`
+- `mods`
+- `services_performed`
+
+All imports of `pgTable`, `serial`, `text`, `integer`, `boolean`, `timestamp`, `varchar` etc. should come from `drizzle-orm/pg-core`.
+
+### 5c. Update `core/db/index.ts` to merge both schemas
+
+```typescript
+// server/src/core/db/index.ts
+import * as coreSchema from './schema.js';
+import * as appSchema from '../../app/db/schema.js';
+
+export const db = drizzle(pool, { schema: { ...coreSchema, ...appSchema } });
+```
+
+> **Note:** This is the one intentional coupling point where core imports from app. It exists because Drizzle needs a single combined schema at the pool level. Document this clearly in the file.
+
+### 5d. Update `drizzle.config.ts`
+
+If `drizzle.config.ts` points to a single schema file, update it to accept both:
+
+```typescript
+// server/drizzle.config.ts
+export default defineConfig({
+  schema: [
+    './src/core/db/schema.ts',
+    './src/app/db/schema.ts',
+  ],
+  // ... rest of config unchanged
+});
+```
+
+---
+
+## Phase 6 — Create `menuRegistry.ts` (new file)
+
+Create `server/src/core/menus/menuRegistry.ts` with this exact content:
+
+```typescript
+import type { AppNode, MenuNode } from '../types/index.js';
+
+const registeredAppItems: AppNode[] = [];
+
+export function registerMenuItems(items: AppNode[]): void {
+  registeredAppItems.push(...items);
+}
+
+export function buildMenuTree(coreAdminNode: MenuNode, logOffNode: AppNode): MenuNode {
+  return {
+    type: 'menu',
+    key: 'main',
+    name: 'Main Menu',
+    title: 'MAIN MENU',
+    items: [
+      ...registeredAppItems,
+      coreAdminNode,
+      logOffNode,
+    ],
+  };
+}
+```
+
+> `AppNode` and `MenuNode` types must exist in `core/types/index.ts`. If they are currently in `menus/menuTree.ts`, move the type definitions to `core/types/index.ts` and re-export from `menuTree.ts` temporarily during migration.
+
+---
+
+## Phase 7 — Trim `menuTree.ts` to Core Nodes Only
+
+Edit `server/src/core/menus/menuTree.ts` to remove all app-specific items (Time Registration, My Garage). The file should only export:
+
+1. The `adminMenuNode: MenuNode` — the Administration submenu with all system admin entries
+2. The `logOffNode: AppNode` — the Log Off action
+
+Example shape after trimming:
+
+```typescript
+// server/src/core/menus/menuTree.ts
+import { PERMISSIONS } from '../services/access.js';
+
+export const adminMenuNode: MenuNode = {
+  type: 'menu',
+  key: 'admin',
+  name: 'Administration',
+  requirePermission: PERMISSIONS.SYS_ADMIN,
+  items: [
+    { type: 'crudtable', key: 'user_mgmt',     name: 'User Management',  configId: 'user_mgmt' },
+    { type: 'crudtable', key: 'role_defaults',  name: 'Role Defaults',    configId: 'role_defaults' },
+    { type: 'crudtable', key: 'auth_tokens',    name: 'Auth Tokens',      configId: 'auth_tokens' },
+    { type: 'crudtable', key: 'oauth_clients',  name: 'OAuth Clients',    configId: 'oauth_clients' },
+    { type: 'crudtable', key: 'mcp_audit',      name: 'MCP Audit Log',    configId: 'mcp_audit' },
+  ],
+};
+
+export const logOffNode: AppNode = {
+  type: 'action',
+  key: 'log_off',
+  name: 'Log Off',
+  action: 'log_off',
+};
+```
+
+---
+
+## Phase 8 — Update `menuRuntime.ts`
+
+`menuRuntime.ts` currently imports `appMenuTree` as a static constant. Change it to call `buildMenuTree()` instead:
+
+```typescript
+// Before
+import { appMenuTree } from './menuTree.js';
+// ... uses appMenuTree
+
+// After
+import { buildMenuTree } from './menuRegistry.js';
+import { adminMenuNode, logOffNode } from './menuTree.js';
+// ... replace usages of appMenuTree with buildMenuTree(adminMenuNode, logOffNode)
+```
+
+If `menuRuntime.ts` calls the tree only once per request (which it should), this change is safe and adds no measurable overhead.
+
+---
+
+## Phase 9 — Create `app/menus/appMenu.ts`
+
+Create `server/src/app/menus/appMenu.ts`. This is where the application declares its menu items:
+
+```typescript
+import { registerMenuItems } from '../../core/menus/menuRegistry.js';
+import { initTimeRegV2Context } from '../configs/timeRegV2.js';
+import { PERMISSIONS } from '../../core/services/access.js';
+
+registerMenuItems([
+  {
+    type: 'crudtable',
+    key: 'time_reg',
+    name: 'Time Registration',
+    requirePermission: PERMISSIONS.TIME_REG_READ,
+    configId: 'timereg_v2',
+    initContext: initTimeRegV2Context,
+  },
+  {
+    type: 'menu',
+    key: 'my_garage',
+    name: 'My Garage',
+    items: [
+      {
+        type: 'crudtable',
+        key: 'motorcycles',
+        name: 'Motorcycles',
+        configId: 'motorcycles',
+      },
+    ],
+  },
+]);
+```
+
+> Copy the exact menu items from the old `menuTree.ts` `items` array, excluding the Admin submenu and Log Off entries.
+
+---
+
+## Phase 10 — Move App Services and Configs
+
+### App services
+
+| Old path | New path |
+|---|---|
+| `server/src/services/jiraTasks.ts` | `server/src/app/services/jiraTasks.ts` |
+| `server/src/services/motorcycleService.ts` | `server/src/app/services/motorcycleService.ts` |
+| `server/src/services/modsService.ts` | `server/src/app/services/modsService.ts` |
+| `server/src/services/servicesPerformedService.ts` | `server/src/app/services/servicesPerformedService.ts` |
+| `server/src/services/timeReg.ts` | `server/src/app/services/timeReg.ts` |
+| `server/src/services/timeRegCrud.ts` | `server/src/app/services/timeRegCrud.ts` |
+
+### App configs
+
+| Old path | New path |
+|---|---|
+| `server/src/configs/motorcyclesConfig.ts` | `server/src/app/configs/motorcyclesConfig.ts` |
+| `server/src/configs/modsConfig.ts` | `server/src/app/configs/modsConfig.ts` |
+| `server/src/configs/servicesPerformedConfig.ts` | `server/src/app/configs/servicesPerformedConfig.ts` |
+| `server/src/configs/timeRegV2.ts` | `server/src/app/configs/timeRegV2.ts` |
+
+---
+
+## Phase 11 — Create `app/index.ts`
+
+Create `server/src/app/index.ts`. This is the app's self-registration entry point — it uses side effects only:
+
+```typescript
+// Import order matters: configs must be registered before menu items are registered,
+// and both must be registered before the server starts handling requests.
+import { registerConfig } from '../core/crudtable/registry.js';
+
+import { timeRegV2Config } from './configs/timeRegV2.js';
+import { motorcyclesConfig } from './configs/motorcyclesConfig.js';
+import { modsConfig } from './configs/modsConfig.js';
+import { servicesPerformedConfig } from './configs/servicesPerformedConfig.js';
+
+registerConfig(timeRegV2Config);
+registerConfig(motorcyclesConfig);
+registerConfig(modsConfig);
+registerConfig(servicesPerformedConfig);
+
+// Menu items — must come after config registration (initContext references config objects)
+import './menus/appMenu.js';
+```
+
+---
+
+## Phase 12 — Create `core/bootstrap.ts`
+
+Create `server/src/core/bootstrap.ts`. This registers all system-level configs and is called once at server startup:
+
+```typescript
+import { registerConfig } from './crudtable/registry.js';
+import { userMgmtConfig } from './configs/userMgmtConfig.js';
+import { roleDefaultsConfig } from './configs/roleDefaultsConfig.js';
+import { authTokensConfig } from './configs/authTokensConfig.js';
+import { oauthClientsConfig } from './configs/oauthClientsConfig.js';
+import { mcpAuditConfig } from './configs/mcpAuditConfig.js';
+
+export function bootstrapCore(): void {
+  registerConfig(userMgmtConfig);
+  registerConfig(roleDefaultsConfig);
+  registerConfig(authTokensConfig);
+  registerConfig(oauthClientsConfig);
+  registerConfig(mcpAuditConfig);
+}
+```
+
+---
+
+## Phase 13 — Update `server/src/index.ts`
+
+The top-level entry point must:
+
+1. Import `app/index.ts` (triggers all app-side registrations as side effects)
+2. Call `bootstrapCore()` (registers all system configs)
+3. Continue with server startup exactly as before
+
+```typescript
+// server/src/index.ts — startup sequence (top of file, before server creation)
+import { bootstrapCore } from './core/bootstrap.js';
+import './app/index.js';   // side-effect: registers app configs + menu items
+
+bootstrapCore();
+// ... rest of server startup unchanged
+```
+
+> The old `server/src/configs/index.ts` file that registered everything together can be deleted once the above is in place.
+
+---
+
+## Phase 14 — Fix All Broken Imports
+
+After moving files, TypeScript will report import errors. Fix them systematically:
+
+### Pattern: core files importing core siblings
+
+Files in `server/src/core/X/` importing from `../db/index.js` → unchanged if `db` is also in `core/`.
+
+### Pattern: app files importing core
+
+```typescript
+// Old (from server/src/services/timeReg.ts)
+import { db } from '../db/index.js';
+import { days } from '../db/schema.js';
+
+// New (from server/src/app/services/timeReg.ts)
+import { db } from '../../core/db/index.js';
+import { days } from '../db/schema.js';  // app schema — same level
+```
+
+```typescript
+// Old (from server/src/configs/timeRegV2.ts)
+import type { CRUDTableConfig } from '../crudtable/types.js';
+
+// New (from server/src/app/configs/timeRegV2.ts)
+import type { CRUDTableConfig } from '../../core/crudtable/types.js';
+```
+
+### Pattern: core files importing core at same depth
+
+Files that moved from `server/src/configs/userMgmtConfig.ts` to `server/src/core/configs/userMgmtConfig.ts` and previously imported `../services/userService.js` → now `../services/userService.js` (unchanged, both are in `core/`).
+
+### Pattern: top-level `index.ts` imports
+
+`server/src/index.ts` imports screens, session, menus etc. All of these shift from `./screens/login.js` to `./core/screens/login.js`.
+
+---
+
+## Phase 15 — Delete Old Empty Directories
+
+Once all files are moved and imports fixed, delete the now-empty source directories:
+
+```
+server/src/configs/    (after moving all files out)
+server/src/crudtable/  (after moving all files out)
+server/src/db/         (after moving all files out)
+server/src/dsl/        (after moving all files out)
+server/src/mcp/        (after moving all files out)
+server/src/menus/      (after moving all files out)
+server/src/screens/    (after moving all files out)
+server/src/services/   (after moving all files out)
+server/src/session/    (after moving all files out)
+server/src/types/      (after moving all files out)
+server/src/utils/      (after moving all files out)
+```
+
+---
+
+## Phase 16 — JIRA Config Cleanup (bonus)
+
+`server/src/app/services/jiraTasks.ts` currently has two hardcoded values that belong in environment variables:
+
+```typescript
+// Current (hardcoded — wrong)
+const baseUrl = 'https://stepwise-as.atlassian.net';
+const userEmail = 'fb@stepwise.no';
+
+// After cleanup (env-driven)
+const baseUrl = process.env.JIRA_BASE_URL ?? '';
+const userEmail = process.env.JIRA_USER_EMAIL ?? '';
+const apiToken = process.env.JIRA_API_TOKEN ?? '';
+```
+
+Add `JIRA_BASE_URL` and `JIRA_USER_EMAIL` to `.env.example` and `DOCS/PRODUCTION_SETUP.md`.
+
+---
+
+## Verification Checklist
+
+Run these after completing all phases:
+
+```bash
+# From project root
+npm run typecheck              # must pass with 0 errors
+
+# From server/
+npm run db:generate            # must detect no schema drift (or only expected new migration)
+
+# From project root
+npm test                       # Playwright E2E — all tests must pass
+
+# Manual smoke test
+docker-compose up
+# Log in as FREDRIC / fredric
+# Verify: Time Registration visible in main menu
+# Verify: My Garage visible in main menu
+# Verify: Administration submenu visible
+# Verify: All CRUD operations work in each screen
+
+# MCP smoke test (from server/)
+node scripts/smoke-mcp.mjs
+```
+
+---
+
+## Notes for a New AS500 Application Developer
+
+After this refactor, the workflow for a developer building a new app on AS500 is:
+
+1. **Define tables** in `server/src/app/db/schema.ts`
+2. **Write services** in `server/src/app/services/myService.ts` using `db` from `../../core/db/index.js`
+3. **Write a config** in `server/src/app/configs/myConfig.ts` implementing `CRUDTableConfig`
+4. **Register the config** in `server/src/app/index.ts` via `registerConfig(myConfig)`
+5. **Add a menu item** in `server/src/app/menus/appMenu.ts` via `registerMenuItems([...])`
+6. Run `npm run db:generate` to create a migration
+
+No files outside `server/src/app/` need to be touched.


### PR DESCRIPTION
DOCS/REFACTOR_SEPARATION.md — agent-executable 16-phase plan for splitting AS500 into a core product layer (core/) and application layer (app/), including the new menuRegistry API and Drizzle schema split.

DOCS/PRODUCTION_SETUP.md — complete production reference covering all environment variables, a .env template, Caddy config, step-by-step server setup, backup/restore, and a pre-launch security checklist.

https://claude.ai/code/session_01SY2nUv7LoYqgyzgPYys394